### PR TITLE
Use quarkus-rest-jackson instead of quarkus-rest-jsonb (v0.5.0)

### DIFF
--- a/.bob-plugin/plugin.json
+++ b/.bob-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications with Bob: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's BOB.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's CLAUDE.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications in Codex: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.4.0
+# Version: 0.5.0
 
 These conventions apply whenever Codex writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in
@@ -60,8 +60,9 @@ generic web search.
 - **CDI-first.** Use `quarkus-arc` and standard CDI (`@ApplicationScoped`, `@Inject`,
   `@Produces`) for wiring. Produce framework objects (retrieval augmentors, memory providers,
   embedding stores) from `@ApplicationScoped` producer beans.
-- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jsonb` for JSON,
-  and expose `quarkus-smallrye-openapi` so endpoints are documented and explorable.
+- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jackson` for JSON
+  (Jackson is the Quarkus default serializer), and expose `quarkus-smallrye-openapi` so endpoints
+  are documented and explorable.
 - **Streaming uses WebSockets Next.** For token or progress streaming, use
   `quarkus-websockets-next` rather than rolling a custom transport (see section 4 for the
   streaming pattern).

--- a/BOB.md
+++ b/BOB.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.4.0
+# Version: 0.5.0
 
 These conventions apply whenever Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in
@@ -60,8 +60,9 @@ generic web search.
 - **CDI-first.** Use `quarkus-arc` and standard CDI (`@ApplicationScoped`, `@Inject`,
   `@Produces`) for wiring. Produce framework objects (retrieval augmentors, memory providers,
   embedding stores) from `@ApplicationScoped` producer beans.
-- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jsonb` for JSON,
-  and expose `quarkus-smallrye-openapi` so endpoints are documented and explorable.
+- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jackson` for JSON
+  (Jackson is the Quarkus default serializer), and expose `quarkus-smallrye-openapi` so endpoints
+  are documented and explorable.
 - **Streaming uses WebSockets Next.** For token or progress streaming, use
   `quarkus-websockets-next` rather than rolling a custom transport (see §4 for the streaming
   pattern).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
+
+## v0.5.0 — 2026-06-03
+- Switched the generated REST JSON serializer from JSON-B to Jackson
+  (`quarkus-rest-jsonb` → `quarkus-rest-jackson`): `pom.xml.template`, the §3 REST convention in
+  `CLAUDE.md` / `AGENTS.md` / `BOB.md`, the `SKILL.md` dependency baseline, and the
+  `docs/VALIDATING-TEMPLATES.md` extension list. Jackson is the Quarkus default JSON serializer,
+  confirmed via the Quarkus Agents MCP against the `rest-json` guide. The Java templates use plain
+  records (no JSON-B annotations), so no code changes were required.
+- Reconciled the `pom.xml.template` platform baseline `3.36.0` → `3.36.1` to match the current
+  Quarkus platform (verified via `quarkus_create`); all 14 template files compile against it.
+- All version headers synchronized to 0.5.0.
+
 ## v0.4.0 — 2026-06-03
 - Added native Bob support alongside the existing Claude and Codex support: `BOB.md`,
   `.bob-plugin/plugin.json`, and Bob-specific plugin metadata for the scaffolding skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.4.0
+# Version: 0.5.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in
@@ -60,8 +60,9 @@ generic web search.
 - **CDI-first.** Use `quarkus-arc` and standard CDI (`@ApplicationScoped`, `@Inject`,
   `@Produces`) for wiring. Produce framework objects (retrieval augmentors, memory providers,
   embedding stores) from `@ApplicationScoped` producer beans.
-- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jsonb` for JSON,
-  and expose `quarkus-smallrye-openapi` so endpoints are documented and explorable.
+- **REST and API surface.** Use `quarkus-rest` (Quarkus REST) with `quarkus-rest-jackson` for JSON
+  (Jackson is the Quarkus default serializer), and expose `quarkus-smallrye-openapi` so endpoints
+  are documented and explorable.
 - **Streaming uses WebSockets Next.** For token or progress streaming, use
   `quarkus-websockets-next` rather than rolling a custom transport (see §4 for the streaming
   pattern).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.4.0
+# Version: 0.5.0
 
 ## What this repository is
 
@@ -230,7 +230,7 @@ global file (or remove just the Quarkus/LangChain4j section you pasted into it).
 
 ## Versioning and changelog
 
-This artifact uses semantic versioning. The current version is **0.4.0**; `CLAUDE.md`,
+This artifact uses semantic versioning. The current version is **0.5.0**; `CLAUDE.md`,
 `AGENTS.md`, `BOB.md`, `SKILL.md`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
 `.bob-plugin/plugin.json`, and this `README.md` each carry a matching version header. See
 [`CHANGELOG.md`](CHANGELOG.md) for release history.

--- a/docs/VALIDATING-TEMPLATES.md
+++ b/docs/VALIDATING-TEMPLATES.md
@@ -20,7 +20,7 @@ before shipping a release, and whenever you touch a template.
    ```
    quarkus_create(
      outputDir = "/tmp", artifactId = "ql4j-validate",
-     extensions = "rest,rest-jsonb,smallrye-openapi,websockets-next,langchain4j-ollama,langchain4j-agentic,langchain4j-easy-rag",
+     extensions = "rest,rest-jackson,smallrye-openapi,websockets-next,langchain4j-ollama,langchain4j-agentic,langchain4j-easy-rag",
      noCode = true, noWrapper = false
    )
    ```
@@ -62,6 +62,12 @@ When you only need to know *"does the template Java still compile against the cu
 
 ## Last validated
 
+- **0.5.0 (2026-06-03):** platform `3.36.1`, `maven.compiler.release` 25. Generated a throwaway
+  project with the `rest-jackson` extension list and compiled all 14 materialized template files
+  (`BUILD SUCCESS`, `javac [... release 25]`) — confirms `quarkus-rest-jackson` resolves on the
+  platform BOM and the agentic API (`@SequenceAgent` / `@ParallelAgent` / `@Output`, `AgenticScope`),
+  WebSockets Next, and Mutiny imports still resolve. Template baseline bumped `3.36.0` → `3.36.1` to
+  match the freshly generated pom.
 - **0.2.0 (2026-06-01):** platform `3.36.0`, `maven.compiler.release` 25. All template files
   compiled (`BUILD SUCCESS`); the agentic API (`dev.langchain4j.agentic.*`, `@SequenceAgent` /
   `@ParallelAgent` / `@Output`, `AgenticScope`), WebSockets Next, and Mutiny imports all resolved.

--- a/skills/quarkus-langchain4j-scaffolding/SKILL.md
+++ b/skills/quarkus-langchain4j-scaffolding/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold and structure new Quarkus + LangChain4j projects, modules,
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.4.0
+# Version: 0.5.0
 
 ## 1. When to use this skill
 
@@ -53,7 +53,7 @@ Start with only the sub-packages a feature needs; add the rest as the project gr
 
 Start from `templates/pom.xml.template`. It pins Java 25 as the minimum, imports the `quarkus-bom`
 and `quarkus-langchain4j-bom` platform BOMs, and includes the core extensions
-(`quarkus-rest` + `quarkus-rest-jsonb`, `quarkus-arc`, `quarkus-smallrye-openapi`,
+(`quarkus-rest` + `quarkus-rest-jackson`, `quarkus-arc`, `quarkus-smallrye-openapi`,
 `quarkus-websockets-next`, `quarkus-langchain4j-ollama`), the test stack (`quarkus-junit` +
 `rest-assured`), the `-parameters` compiler flag, and a `native` profile. The template marks
 which dependencies to add for **agents** (`quarkus-langchain4j-agentic`) and for **RAG**

--- a/skills/quarkus-langchain4j-scaffolding/templates/pom.xml.template
+++ b/skills/quarkus-langchain4j-scaffolding/templates/pom.xml.template
@@ -25,7 +25,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.36.0</quarkus.platform.version>
+        <quarkus.platform.version>3.36.1</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
@@ -50,14 +50,14 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Core: REST + JSON-B + OpenAPI -->
+        <!-- Core: REST + Jackson (JSON) + OpenAPI -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jsonb</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## What & why

A Quarkus maintainer reviewing the plugin pointed out that the generated REST stack should use **Jackson**, not JSON-B — Jackson is the Quarkus default JSON serializer.

Confirmed via the Quarkus Agents MCP against the official [rest-json guide](https://quarkus.io/guides/rest-json), which presents Jackson as the primary path and describes JSON-B as *"the option of using JSON-B instead of Jackson"*. The correct extension is `quarkus-rest-jackson`.

## Changes

- Swap `quarkus-rest-jsonb` → `quarkus-rest-jackson`: `pom.xml.template`, the §3 REST convention in `CLAUDE.md` / `AGENTS.md` / `BOB.md`, the `SKILL.md` dependency baseline, and the `docs/VALIDATING-TEMPLATES.md` extension list.
- Java templates use plain records (no JSON-B annotations), so no Java changes were needed.
- Reconcile the `pom.xml.template` platform baseline `3.36.0` → `3.36.1` to match a freshly generated project.
- Bump all version headers `0.4.0` → `0.5.0` + CHANGELOG entry.

## Validation

Static fallback per `docs/VALIDATING-TEMPLATES.md`: generated a throwaway project with the `rest-jackson` extension list and compiled all 14 materialized template files against platform 3.36.1:

```
Compiling 14 source files with javac [debug parameters release 25]
BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)