### PR TITLE
Slim pom.xml.template to a dependency reference (v0.6.0)

### DIFF
--- a/.bob-plugin/plugin.json
+++ b/.bob-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications with Bob: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's BOB.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's CLAUDE.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications in Codex: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.5.0
+# Version: 0.6.0
 
 These conventions apply whenever Codex writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/BOB.md
+++ b/BOB.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.5.0
+# Version: 0.6.0
 
 These conventions apply whenever Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.6.0 — 2026-06-03
+- Slimmed `pom.xml.template` from a full pom to a dependency reference. The project shell (platform
+  BOMs, build plugins, the `-parameters` flag, the `native` profile, the test stack, version pins) is
+  generated up to date by `quarkus_create` — the same codestart generator behind code.quarkus.io — so
+  hand-maintaining it only caused drift (see v0.5.0). The template now keeps only what generators do
+  not provide: the curated extension list and the non-extension `dev.langchain4j` deps (embedding
+  model, PDF parser). Updated `SKILL.md` §3 and the `VALIDATING-TEMPLATES.md` reconcile step to match.
+- All version headers synchronized to 0.6.0.
+
 ## v0.5.0 — 2026-06-03
 - Switched the generated REST JSON serializer from JSON-B to Jackson
   (`quarkus-rest-jsonb` → `quarkus-rest-jackson`): `pom.xml.template`, the §3 REST convention in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.5.0
+# Version: 0.6.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.5.0
+# Version: 0.6.0
 
 ## What this repository is
 
@@ -230,7 +230,7 @@ global file (or remove just the Quarkus/LangChain4j section you pasted into it).
 
 ## Versioning and changelog
 
-This artifact uses semantic versioning. The current version is **0.5.0**; `CLAUDE.md`,
+This artifact uses semantic versioning. The current version is **0.6.0**; `CLAUDE.md`,
 `AGENTS.md`, `BOB.md`, `SKILL.md`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
 `.bob-plugin/plugin.json`, and this `README.md` each carry a matching version header. See
 [`CHANGELOG.md`](CHANGELOG.md) for release history.

--- a/docs/VALIDATING-TEMPLATES.md
+++ b/docs/VALIDATING-TEMPLATES.md
@@ -25,10 +25,12 @@ before shipping a release, and whenever you touch a template.
    )
    ```
 
-2. **Reconcile the version.** Read `quarkus.platform.version` from the generated `pom.xml`. If it is
-   newer than the value in `pom.xml.template`, update the template (it is a reference baseline only).
-   Also confirm the generated pom still imports `quarkus-langchain4j-bom` under
-   `io.quarkus.platform` at the platform version — the template assumes this.
+2. **Reconcile dependencies.** `pom.xml.template` no longer pins a platform version — `quarkus_create`
+   owns the shell. Instead, confirm the generated `pom.xml` imports both `quarkus-bom` and
+   `quarkus-langchain4j-bom` under `io.quarkus.platform`, and that the extension list above still
+   resolves. Then confirm the **non-extension** deps in `pom.xml.template`
+   (`langchain4j-embeddings-all-minilm-l6-v2`, `langchain4j-document-parser-apache-pdfbox`) still
+   resolve via the BOM with no explicit `<version>`.
 
 3. **Materialize the templates** into `src/main/java/org/acme/` and `src/main/resources/`:
    - copy `AiService.java.template` → `ai/ChatAssistant.java`
@@ -62,6 +64,11 @@ When you only need to know *"does the template Java still compile against the cu
 
 ## Last validated
 
+- **0.6.0 (2026-06-03):** platform `3.36.1`. After slimming `pom.xml.template` to a dependency
+  reference: regenerated the shell via `quarkus_create` (core + agents + RAG — all extensions
+  resolved) and confirmed the two non-extension deps now listed in the template
+  (`langchain4j-embeddings-all-minilm-l6-v2`, `langchain4j-document-parser-apache-pdfbox`) resolve
+  via `quarkus-langchain4j-bom` with **no** `<version>` (1.14.1-beta24). `BUILD SUCCESS`.
 - **0.5.0 (2026-06-03):** platform `3.36.1`, `maven.compiler.release` 25. Generated a throwaway
   project with the `rest-jackson` extension list and compiled all 14 materialized template files
   (`BUILD SUCCESS`, `javac [... release 25]`) — confirms `quarkus-rest-jackson` resolves on the

--- a/skills/quarkus-langchain4j-scaffolding/SKILL.md
+++ b/skills/quarkus-langchain4j-scaffolding/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold and structure new Quarkus + LangChain4j projects, modules,
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.5.0
+# Version: 0.6.0
 
 ## 1. When to use this skill
 
@@ -51,16 +51,21 @@ Start with only the sub-packages a feature needs; add the rest as the project gr
 
 ## 3. Dependency baseline
 
-Start from `templates/pom.xml.template`. It pins Java 25 as the minimum, imports the `quarkus-bom`
-and `quarkus-langchain4j-bom` platform BOMs, and includes the core extensions
-(`quarkus-rest` + `quarkus-rest-jackson`, `quarkus-arc`, `quarkus-smallrye-openapi`,
-`quarkus-websockets-next`, `quarkus-langchain4j-ollama`), the test stack (`quarkus-junit` +
-`rest-assured`), the `-parameters` compiler flag, and a `native` profile. The template marks
-which dependencies to add for **agents** (`quarkus-langchain4j-agentic`) and for **RAG**
-(`quarkus-langchain4j-easy-rag` + an in-process embedding model).
+Create the project with `quarkus_create` and let it generate the shell. The generated `pom.xml`
+already imports the `quarkus-bom` and `quarkus-langchain4j-bom` platform BOMs, sets Java 25, enables
+the `-parameters` compiler flag, adds a `native` profile, and pulls in the test stack
+(`quarkus-junit` + `rest-assured`) — all at the current platform version. Do not hand-maintain any
+of that: `quarkus_create` (the same codestart generator behind code.quarkus.io) keeps it up to date.
 
-When creating the project through the Quarkus Agents MCP, pass the matching extensions to
-`quarkus_create` and reconcile the generated `pom.xml` with the template.
+Pass these extensions to `quarkus_create`:
+
+- core: `rest`, `rest-jackson`, `smallrye-openapi`, `websockets-next`, `langchain4j-ollama`
+- agents: add `langchain4j-agentic`
+- RAG: add `langchain4j-easy-rag`
+
+(`quarkus-arc` comes in automatically.) Then add the **non-extension** dependencies listed in
+`templates/pom.xml.template` — the `dev.langchain4j` embedding model (required by Easy RAG) and,
+for PDFs, the document parser — since project generators add only Quarkus extensions, not those.
 
 ## 4. AI service scaffolding
 

--- a/skills/quarkus-langchain4j-scaffolding/templates/pom.xml.template
+++ b/skills/quarkus-langchain4j-scaffolding/templates/pom.xml.template
@@ -1,197 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Quarkus + LangChain4j single-module starter.
-  - Java 25 is the MINIMUM language level (raise it freely; do not lower it without a documented reason).
-  - Versions are managed by the platform BOMs; do not pin individual extension versions.
-  - quarkus.platform.version below is a REFERENCE BASELINE, not the source of truth. The authoritative
-    current version comes from the Quarkus Agents MCP (quarkus_create) — reconcile this pom against a
-    freshly generated one and update the version before shipping.
-  Replace org.acme / quarkus-langchain4j-starter with your own coordinates.
+  Quarkus + LangChain4j — DEPENDENCY REFERENCE (this is NOT a full pom.xml).
+
+  The project SHELL — the full pom.xml: the quarkus-bom + quarkus-langchain4j-bom platform BOMs,
+  the build plugins, the `-parameters` compiler flag (parameter-name retention), the `native`
+  profile, the test stack, and every version pin — is generated, already up to date, by the
+  Quarkus Agents MCP `quarkus_create` (the same codestart generator that powers code.quarkus.io).
+  It is intentionally NOT hand-maintained here: a pinned copy only drifts (in v0.5.0 the baseline
+  had already fallen behind the live platform).
+
+  So this file keeps only the two things a project generator does NOT give you.
+
+  ==========================================================================
+  1. Extensions to pass to quarkus_create (resolved against the current platform BOM)
+  ==========================================================================
+    core:    rest, rest-jackson, smallrye-openapi, websockets-next, langchain4j-ollama
+    agents:  + langchain4j-agentic     (declarative LangChain4j Agentic workflows)
+    RAG:     + langchain4j-easy-rag     (Easy RAG)
+
+  quarkus-arc, quarkus-junit and rest-assured are pulled in automatically — do not list them.
+
+  ==========================================================================
+  2. Non-extension dependencies the generator does NOT add — paste into <dependencies>
+  ==========================================================================
+  These live under the dev.langchain4j group (they are libraries, not Quarkus extensions), so
+  neither quarkus_create nor code.quarkus.io will add them. Their versions are managed by
+  quarkus-langchain4j-bom, so they take NO <version>.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<dependencies>
 
-    <groupId>org.acme</groupId>
-    <artifactId>quarkus-langchain4j-starter</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>quarkus</packaging>
+    <!-- RAG: in-process embedding model required by Easy RAG -->
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+    </dependency>
 
-    <properties>
-        <compiler-plugin.version>3.15.0</compiler-plugin.version>
-        <maven.compiler.release>25</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.36.1</quarkus.platform.version>
-        <skipITs>true</skipITs>
-        <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    </properties>
+    <!-- RAG: add only if ingesting PDFs -->
+    <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId>
+    </dependency>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>quarkus-langchain4j-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <dependencies>
-        <!-- Core: REST + Jackson (JSON) + OpenAPI -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-openapi</artifactId>
-        </dependency>
-
-        <!-- CDI -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-        </dependency>
-
-        <!-- Streaming transport (WebSockets Next) -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-websockets-next</artifactId>
-        </dependency>
-
-        <!-- LLM provider: Ollama (default base-url http://localhost:11434) -->
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-ollama</artifactId>
-        </dependency>
-
-        <!-- ====== Add for AGENT workflows (declarative LangChain4j Agentic) ====== -->
-        <!--
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-agentic</artifactId>
-        </dependency>
-        -->
-
-        <!-- ====== Add for RAG (Easy RAG + an in-process embedding model) ====== -->
-        <!--
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-easy-rag</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-        </dependency>
-        -->
-        <!-- Add only if ingesting PDFs:
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId>
-        </dependency>
-        -->
-
-        <!-- Test -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
-                <configuration>
-                    <!-- Parameter-name retention is required by REST and AI-service binding. -->
-                    <parameters>true</parameters>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <maven.home>${maven.home}</maven.home>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <systemPropertyVariables>
-                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <maven.home>${maven.home}</maven.home>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <!-- Build a GraalVM native binary with: mvn verify -Dnative -->
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <skipITs>false</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
-                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
-            </properties>
-        </profile>
-    </profiles>
-</project>
+</dependencies>


### PR DESCRIPTION
## What & why

Second piece of feedback from the same Quarkus maintainer: don't hand-maintain setup instructions (the full pom, parameter-name retention, etc.) — let the generator produce an always-up-to-date shell.

Confirmed via the Quarkus MCP: the [extension-codestart guide](https://quarkus.io/guides/extension-codestart) states the codestart generator is shared by `code.quarkus.io`, the `quarkus-maven-plugin:create`, and `quarkus create app`. So `quarkus_create` (which the plugin already mandates) **is** the same generator behind code.quarkus.io. And in v0.5.0 our hand-pinned `pom.xml.template` had already drifted (3.36.0 vs the live 3.36.1).

## Change

`pom.xml.template` goes from a full pom to a **dependency reference** that keeps only what project generators do NOT provide:
- the curated extension list to pass to `quarkus_create`;
- the non-extension `dev.langchain4j` deps (embedding model, PDF parser), versioned by `quarkus-langchain4j-bom` (no `<version>`).

Everything `quarkus_create` already emits — BOMs, build plugins, `-parameters`, the `native` profile, the test stack, version pins — is removed (and with it, the drift).

- `SKILL.md` §3 and the `VALIDATING-TEMPLATES.md` reconcile step rewritten to match.
- Conventions §3 (CLAUDE/AGENTS/BOB) unchanged — `-parameters` and native remain rules the generator satisfies.
- Deferred (not in this PR): a `code.quarkus.io` HTTP fallback for no-MCP environments (e.g. CI).

## Validation

`quarkus_create` resolved all extensions (core + agents + RAG) on platform 3.36.1, and the two non-extension deps resolved via `quarkus-langchain4j-bom` with **no** `<version>` (1.14.1-beta24). `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)