### PR TITLE
chore: add plugin displayName "Quarkus Agentic Scaffolding" (v0.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,6 +7,7 @@
   "plugins": [
     {
       "name": "quarkus-agentic",
+      "displayName": "Quarkus Agentic Scaffolding",
       "source": {
         "source": "github",
         "repo": "eldermoraes/quarkus-agentic-scaffolding"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.10.0",
+  "displayName": "Quarkus Agentic Scaffolding",
+  "version": "0.10.1",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's CLAUDE.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Scaffolding skill for building Quarkus + LangChain4j agentic AI applications in Codex: new projects, AI services, agents/workflows, and RAG pipelines. Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.10.0
+# Version: 0.10.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.10.1 — 2026-07-13
+- Added a `displayName` of "Quarkus Agentic Scaffolding" to the plugin so the Claude Code UI
+  shows a proper human-readable label instead of the prettified `quarkus-agentic` slug. The field
+  is set in both `.claude-plugin/plugin.json` and the `.claude-plugin/marketplace.json` plugin
+  entry (the marketplace entry wins for users installing from this marketplace, with `plugin.json`
+  as the fallback), so installed users see the new name. The `name` identifier stays
+  `quarkus-agentic`, so skill namespacing and install identity are unchanged. `displayName`
+  requires Claude Code v2.1.143+ and falls back to `name` on older clients. This brings the Claude
+  Code manifests to parity with the Codex manifest, which already carried the same display name.
+- All version headers synchronized to 0.10.1.
+
 ## v0.10.0 — 2026-07-10
 - Added MCP scaffolding in both directions: `McpClient.java.template` (an AI service consuming
   MCP tools via `@McpToolBox`, with `streamable-http`/`stdio` client config in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.10.0
+# Version: 0.10.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.10.0
+# Version: 0.10.1
 
 ## What this repository is
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Scaffolding skill and always-on conventions for building Quarkus + LangChain4j agentic AI applications: new projects, AI services, agents and workflows, and RAG pipelines.",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/quarkus-langchain4j-scaffolding/SKILL.md
+++ b/skills/quarkus-langchain4j-scaffolding/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold and structure new Quarkus + LangChain4j projects, modules,
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.10.0
+# Version: 0.10.1
 
 ## 1. When to use this skill
 


### PR DESCRIPTION
## O que muda

Adiciona `displayName: "Quarkus Agentic Scaffolding"` ao plugin para que a UI do Claude Code mostre um rótulo legível no lugar do slug `quarkus-agentic` "embelezado".

O campo é definido em **dois** lugares que o instalador lê:
- `.claude-plugin/plugin.json` (viaja com o plugin — fallback)
- a entrada do plugin em `.claude-plugin/marketplace.json` (tem precedência para quem instala a partir deste marketplace)

Assim o nome vale para **usuários que instalam** o plugin, não só localmente.

## Por que é seguro

- O identificador `name` continua `quarkus-agentic` → namespacing das skills (`quarkus-agentic:...`) e identidade de instalação **não mudam**.
- `displayName` requer Claude Code **v2.1.143+**; em clientes anteriores cai de volta no `name` (degradação suave).
- Traz os manifestos do Claude Code à **paridade** com o do Codex, que já carregava esse mesmo nome.

## Release

Bump para **0.10.1** nos 7 arquivos versionados + entrada no CHANGELOG (sinaliza atualização para quem já instalou).

## Verificação

- `ci/check-version-consistency.sh` → OK (7 arquivos em 0.10.1)
- `ci/check-conventions-parity.sh` → OK
- JSONs validados

🤖 Generated with [Claude Code](https://claude.com/claude-code)