### PR TITLE
fix: pin the JDK on the MCP launch and correct Bob's global config path (v0.18.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: actions/checkout@v7
       - run: ci/check-version-consistency.sh
 
+  mcp-command-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: ci/check-mcp-command-consistency.sh
+
   conventions-parity:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.17.0
+# Version: 0.18.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ versioning.
   The `quarkus-agent-mcp@quarkusio` alias is not an escape hatch: it *does* declare
   `java-version: 21+`, but JBang 0.125.x ignores that for a GAV `script-ref` and fails identically
   (also verified). `21+` is a floor rather than a pin, so a machine already on 25 reuses it instead
-  of downloading JDK 21. Touches the four `mcp add` rows and the JSON snippet in the setup skill,
-  the Codex/Gemini/Bob commands and both snippets in `README.md`, and `gemini-extension.json`. The
+  of downloading JDK 21. Touches all five `mcp add` rows, the args line in §5, and the JSON snippet
+  in the setup skill, the Claude/Codex/Gemini/Bob commands and both snippets in `README.md`, and
+  `gemini-extension.json` — 16 occurrences, now coupled by a gate (below) rather than by hand. The
   Renovate pin still resolves — its `matchStrings` anchor on the GAV, which the flag precedes.
 - **Bob's global MCP file was documented at a path Bob never reads.** We published
   `~/.bob/mcp.json` (with a hedge toward `mcp_settings.json`); Bob 2.0.0's own constants are
@@ -55,10 +56,45 @@ versioning.
   `.bob/mcp.json` as the MCP registration the uninstall must not touch — which under `--global` is
   now `~/.bob/settings/mcp.json`. Both scopes are spelled out, in the script and in the README's Bob
   uninstall paragraph. Behavior unchanged: the script never touched those files.
-- **The upstream Claude plugin carries the same JDK trap, and the README now says so.**
-  `quarkus-agent@quarkus-tools` launches `jbang quarkus-agent-mcp@quarkusio` with no JDK pin, so the
-  Claude manual-fallback path points at the pinned `claude mcp add` command as the fix if that
-  server never comes up.
+- **New gate: `ci/check-mcp-command-consistency.sh`.** The command is hand-maintained in 16 places;
+  the version gate couples the *version* and Renovate the *GAV*, but nothing coupled the *command*,
+  so `--java 21+` could be present in one artifact and missing in another with every check green —
+  a class of drift this repo has already hit (`9fdb9d2`). The script normalizes each published
+  surface (markdown, CLI, JSON args, `add-json` payload) and fails unless every occurrence is
+  preceded by the pin and carries the same version. Wired into `quality.yml`; `CHANGELOG.md` and
+  `docs/` are exempt, since they quote older commands as a record. Proven to fail on a
+  single unpinned copy before being committed.
+- **Verification now reads the stored command, not the server's name.** Every Verify cell checked
+  only that something called `quarkus-agent` was listed — which an unpinned entry from an earlier
+  release or from the upstream Claude plugin satisfies, so no existing install was ever repaired and
+  all of them were reported verified. §5 requires comparing the printed command to the canonical
+  string and treating a mismatch as a repair (replace the entry: `add-json` for Bob, remove + re-add
+  elsewhere), and reporting both strings.
+- **`jbang` itself may be unreachable, which no JDK flag can fix.** A GUI- or IDE-launched client
+  starts from launchd/systemd with a minimal PATH (`launchctl getenv PATH` is empty on macOS →
+  `/usr/bin:/bin:/usr/sbin:/sbin`), where none of SDKMAN, Homebrew, or the upstream installer put
+  `jbang`; the symptom is `spawn jbang ENOENT`. "`jbang` must be on PATH — that is Phase A's job"
+  was the same category error this release fixes for `JAVA_HOME`: Phase A probes the login shell,
+  not the spawn environment. Both files now say to register the absolute path from
+  `command -v jbang` when a client fails that way.
+- **Phase A installs a 21+ JDK for JBang instead of letting the first handshake do it.** With no
+  JBang-managed 21+ and no visible `JAVA_HOME`, `--java 21+` makes JBang download a JDK *inside* MCP
+  startup: `initialize` times out and reads as "the MCP is broken" on first run. Phase A now checks
+  `jbang jdk list` and offers `jbang jdk install 21` in the foreground.
+- **Bob's route no longer hard-depends on the `bob` binary**, and its handoff is honest. §5.1 probes
+  `command -v bob` and keeps a hand-write path (read-modify-write, both real paths, verified in the
+  UI's MCP tab) for IDE-only machines. And while Bob restarts changed *servers* by itself, it loads
+  skills and the conventions file once per conversation — §5.2 now closes a Bob run by telling the
+  user to start a new conversation before `/scaffold-project`.
+- **The upstream Claude plugin carries the same JDK trap, and the README now says so** — with the
+  right reason. `quarkus-agent@quarkus-tools` launches `jbang quarkus-agent-mcp@quarkusio`: the
+  alias *does* declare `java-version: 21+` and JBang 0.125.x ignores it for a GAV `script-ref`, and
+  `RELEASE` resolution means two machines run different code. The Claude manual fallback leads with
+  the pinned `claude mcp add` (both servers at `-s user`), and the plugin is presented as the
+  alternative with the name-collision warning the repo already gives for Gemini.
+- **`ci/test-uninstall-bob-skill.sh` now covers the `--global` half of the MCP boundary.** Case 6
+  redirects `HOME` but never fixtured `~/.bob/settings/mcp.json`, so the file this release promises
+  to preserve under `--global` — where `BASE="$HOME"` — was asserted nowhere. Two asserts close it.
 
 ## v0.17.0 — 2026-08-10
 - **Documented how to uninstall this artifact — and only this artifact.** New `## Uninstall`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.18.0 — 2026-08-10
+- **Every published Quarkus Agents MCP registration now pins the JDK: `jbang --java 21+
+  io.quarkus:quarkus-agent-mcp:1.2.5:runner`.** The old command shipped no JDK hint, and §5 of the
+  setup skill justified that by saying the missing `java-version: 21+` was "moot here, because
+  Phase A already requires JDK 25+". That reasoning was the bug: Phase A proves the *machine* has a
+  JDK 25, but JBang resolves its own JDK and falls back to its default — 17 on JBang 0.125.x —
+  whenever the spawning process exports no `JAVA_HOME` (GUI- and IDE-launched agents typically do
+  not) or points below 21. The server is compiled for Java 21, so it died at boot with
+  `UnsupportedClassVersionError: … class file version 65.0 … up to 61.0`, the client retried and
+  gave up, and it read as "the MCP is broken". Verified by MCP `initialize` handshake against 1.2.5:
+  the old command **fails** with no `JAVA_HOME` and passes with `JAVA_HOME=25` — so a
+  terminal-launched agent was passing by accident of its environment; `--java 21+` passes in both.
+  The `quarkus-agent-mcp@quarkusio` alias is not an escape hatch: it *does* declare
+  `java-version: 21+`, but JBang 0.125.x ignores that for a GAV `script-ref` and fails identically
+  (also verified). `21+` is a floor rather than a pin, so a machine already on 25 reuses it instead
+  of downloading JDK 21. Touches the four `mcp add` rows and the JSON snippet in the setup skill,
+  the Codex/Gemini/Bob commands and both snippets in `README.md`, and `gemini-extension.json`. The
+  Renovate pin still resolves — its `matchStrings` anchor on the GAV, which the flag precedes.
+- **Bob's global MCP file was documented at a path Bob never reads.** We published
+  `~/.bob/mcp.json` (with a hedge toward `mcp_settings.json`); Bob 2.0.0's own constants are
+  `MCP_WORKSPACE_FILENAME = "mcp.json"` (→ `<project>/.bob/mcp.json`, correct), `MCP_GLOBAL_FILENAME
+  = "mcp.json"` in the global settings directory (→ **`~/.bob/settings/mcp.json`**), and
+  `MCP_LEGACY_GLOBAL_FILENAME = "mcp_settings.json"`, which Bob migrates **only when `mcp.json` does
+  not yet exist**. So on any machine that already has `mcp.json`, a registration written to the
+  legacy name is silently ignored — the setup reports success and Bob never loads the server. New
+  §5.1 in the setup skill documents the two real paths, the legacy trap, and the precedence rules,
+  and `README.md`'s uninstall boundary now names the global file it keeps.
+- **Bob registration switches from hand-written JSON to `bob mcp add` (Bob 2.0.0), verified against
+  the CLI.** `bob mcp add -s global <name> jbang -- --java 21+ <GAV>` writes
+  `~/.bob/settings/mcp.json`, creating the file and directory when missing, and `bob mcp list` is a
+  real verification in the same style as the other agent rows. Two behaviors that cost a run if you
+  do not know them, both reproduced in a scratch workspace: the `--` separator is **mandatory**
+  (without it Bob parses the server's flag as its own and exits `error: unknown option '--java'`),
+  and `-s workspace` does **not** create `.bob/mcp.json` — it exits `Fatal error: ENOENT`. Bob also
+  watches the file and restarts the servers whose entry changed (`Restarting changed servers` in
+  `~/.bob/logs/shell/`), so its "Live this session?" cell moves from "Reload in UI" to yes.
+- **The upstream Claude plugin carries the same JDK trap, and the README now says so.**
+  `quarkus-agent@quarkus-tools` launches `jbang quarkus-agent-mcp@quarkusio` with no JDK pin, so the
+  Claude manual-fallback path points at the pinned `claude mcp add` command as the fix if that
+  server never comes up.
+
 ## v0.17.0 — 2026-08-10
 - **Documented how to uninstall this artifact — and only this artifact.** New `## Uninstall`
   section in `README.md`, placed after *Advanced — personal use* because it depends on what that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ versioning.
   and `-s workspace` does **not** create `.bob/mcp.json` — it exits `Fatal error: ENOENT`. Bob also
   watches the file and restarts the servers whose entry changed (`Restarting changed servers` in
   `~/.bob/logs/shell/`), so its "Live this session?" cell moves from "Reload in UI" to yes.
+- **`bob mcp add` cannot repair a stale entry; `add-json` can.** Verified: on a name that already
+  exists, `add` exits 1 with `Error: MCP server "…" already exists in …` and leaves the old entry
+  intact — so an idempotent re-run could not have replaced an unpinned registration through the route
+  this release recommends. §5.1 and the README now document
+  `bob mcp add-json -s <scope> quarkus-agent '{…}'`, which overwrites in place, with a
+  confirm-before-overwrite rule.
+- **Registrations written by earlier releases of this skill sit one directory above where Bob looks.**
+  Before v0.18.0 we pointed agents at `~/.bob/mcp.json` / `~/.bob/mcp_settings.json`; Bob reads
+  neither and migrates neither (its legacy migration only ever looks inside the settings directory),
+  so a machine set up by an earlier run can hold a registration that has never loaded. Both the skill
+  and the README now name those two orphan paths as things to check, not just the settings directory.
+- **`scripts/uninstall-bob-skill.sh`'s boundary comment and `--help` named the wrong files.** They
+  listed a `settings.json` file where Bob 2.0.0 has a `settings/` directory, and named only
+  `.bob/mcp.json` as the MCP registration the uninstall must not touch — which under `--global` is
+  now `~/.bob/settings/mcp.json`. Both scopes are spelled out, in the script and in the README's Bob
+  uninstall paragraph. Behavior unchanged: the script never touched those files.
 - **The upstream Claude plugin carries the same JDK trap, and the README now says so.**
   `quarkus-agent@quarkus-tools` launches `jbang quarkus-agent-mcp@quarkusio` with no JDK pin, so the
   Claude manual-fallback path points at the pinned `claude mcp add` command as the fix if that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.17.0
+# Version: 0.18.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,15 @@ Conventions and templates should reflect how real Quarkus + LangChain4j systems 
 This artifact uses semantic versioning. Keep the version header identical across `README.md`,
 `CLAUDE.md`, `AGENTS.md`, the three `skills/*/SKILL.md` files, `.claude-plugin/plugin.json`,
 `.codex-plugin/plugin.json`, and `gemini-extension.json` (nine files, enforced by
-`ci/check-version-consistency.sh`), and record every change in `CHANGELOG.md`.
+`ci/check-version-consistency.sh`), and record every change in `CHANGELOG.md`. A version bump also
+reaches the two seed copies the setup skill ships —
+`skills/setup-agentic-scaffolding/templates/conventions-{CLAUDE,AGENTS}.md` — so re-copy the root
+files over them; `ci/check-conventions-parity.sh` fails on the drift otherwise.
+
+The launch command for the Quarkus Agents MCP is hand-maintained in ~15 places, and
+`ci/check-mcp-command-consistency.sh` couples them: every published registration must carry
+`--java 21+` and the same pinned GAV version. `CHANGELOG.md` and `docs/` are exempt, because they
+quote older commands as a record.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,15 @@ bob mcp list
 
 The `--` is required: without it Bob parses `--java` as one of its own options and exits with
 `error: unknown option '--java'`. Use `-s workspace` to register in the current project instead —
-but at that scope the file must already exist, or the command dies with `ENOENT … .bob/mcp.json`;
-run `mkdir -p .bob && echo '{"mcpServers":{}}' > .bob/mcp.json` first. At global scope Bob creates
-the file and its directory for you. On a name that is already registered, `add` refuses
+but at that scope the file must already exist, or the command dies with `ENOENT … .bob/mcp.json`.
+Seed it **only if it is missing** — `>` truncates, and an existing file holds registrations worth
+keeping:
+
+```
+[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }
+```
+
+At global scope Bob creates the file and its directory for you. On a name that is already registered, `add` refuses
 (`Error: MCP server "quarkus-agent" already exists`) — to *replace* a stale entry use
 `bob mcp add-json -s global quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.5:runner"]}'`,
 which overwrites in place.
@@ -152,7 +158,11 @@ To write the JSON by hand instead, the global file is `~/.bob/settings/mcp.json`
 file is `<project>/.bob/mcp.json` (a same-named server at project scope overrides global). Older
 Bob docs name `mcp_settings.json` in that same settings directory; Bob 2.0.0 treats it as legacy and
 migrates it **only when `mcp.json` does not yet exist**, so on a machine that already has `mcp.json`
-anything written to the legacy name is silently ignored. If you set Bob up with a version of this
+anything written to the legacy name is silently ignored. That cuts both ways, so **look before you
+register**: if `~/.bob/settings/mcp_settings.json` exists and `mcp.json` does not, start Bob once and
+let it migrate (it says so — *"your global MCP configuration has been migrated to mcp.json"*) before
+running any `bob mcp add`. Adding first creates `mcp.json` yourself, and the migration then never
+runs — your old servers stay in the legacy file, unread. If you set Bob up with a version of this
 guide before v0.18.0, also look for `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` — one directory
 above `settings/`, which is where we used to point you; Bob reads neither, so a registration sitting
 there has never loaded. Contents either way:
@@ -267,7 +277,9 @@ copying the file into each project:
   context file. (Bob also loads global *rules* from `~/.bob/rules/`, so
   `~/.bob/rules/quarkus-langchain4j.md` works too if you would rather keep them separate from your
   general context.) Install the skills globally with `./scripts/install-bob-skill.sh --global`
-  (into `~/.bob/skills/`), and add shared MCP servers from the **MCP** tab's **Edit Global MCP**.
+  (into `~/.bob/skills/`), and add the shared MCP servers with the `bob mcp add -s global` commands
+  from [How to use with Bob](#how-to-use-with-bob) — not by hand in the **MCP** tab, which is how a
+  registration ends up without the `--java 21+` pin.
 
 **Trade-off (stated explicitly):** the global files apply to **all** work on your machine or
 agent profile. If you also work in other stacks (other languages, frameworks, or non-AI Java
@@ -297,9 +309,13 @@ them with your agent's own MCP commands; nothing here does it for you.
 | The global conventions, if you did the [Advanced](#advanced--personal-use-optional-global-install) install | `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.bob/AGENTS.md` or `~/.bob/rules/<your-file>.md` |
 
 The MCP config files `/setup-agentic-scaffolding` may have written are **kept**: `.cursor/mcp.json`,
-`opencode.json`, and Bob's `.bob/mcp.json` (project) or `~/.bob/settings/mcp.json` (global). Their
-entire content is the two MCP servers this boundary protects, so deleting them would remove exactly
-what you asked to keep.
+`opencode.json`, and Bob's `.bob/mcp.json` (project) or `~/.bob/settings/mcp.json` (global).
+Deleting them would remove exactly what this boundary protects — and for the two Bob files that is
+not even the whole story: `bob mcp add` merges into whatever is already there, so a global
+`~/.bob/settings/mcp.json` typically holds servers that have nothing to do with this artifact
+(possibly with credentials in them). If you do want our two servers gone, remove them **by entry**,
+never by file: `bob mcp remove -s global quarkus-agent` and `bob mcp remove -s global context7`
+(`-s workspace` for a project file), then `bob mcp list` to confirm what remains.
 
 ### 1. The skills
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ keeping:
 At global scope Bob creates the file and its directory for you. On a name that is already registered, `add` refuses
 (`Error: MCP server "quarkus-agent" already exists`) — to *replace* a stale entry use
 `bob mcp add-json -s global quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.5:runner"]}'`,
-which overwrites in place.
+which overwrites in place. Read what `bob mcp list` prints, not just the name: an entry from an older
+setup shows its own command (an unpinned `jbang quarkus-agent-mcp@quarkusio`, say) and is exactly the
+case `add-json` is for.
 
 To write the JSON by hand instead, the global file is `~/.bob/settings/mcp.json` and the project
 file is `<project>/.bob/mcp.json` (a same-named server at project scope overrides global). Older
@@ -176,8 +178,11 @@ there has never loaded. Contents either way:
 }
 ```
 
-(`jbang` must be on your PATH — install it with a package manager, e.g. `sdk install jbang` or
-`brew install jbang`. `--java 21+` is not optional: the MCP server is compiled for Java 21, and JBang
+(`jbang` must be on the PATH of whatever *starts* Bob — install it with a package manager, e.g.
+`sdk install jbang` or `brew install jbang`. A GUI-launched client gets a minimal PATH that contains
+none of the usual install locations, so if the server fails with `spawn jbang ENOENT`, put the
+absolute path from `command -v jbang` in `command` and keep the args as they are. `--java 21+` is not
+optional: the MCP server is compiled for Java 21, and JBang
 resolves its own JDK — it falls back to its default, currently 17, whenever the process that spawned
 it hands over no `JAVA_HOME`, which is exactly what Bob and other GUI-launched clients do. For higher
 rate limits `export CONTEXT7_API_KEY=…` in your environment rather than writing a literal key into

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.17.0
+# Version: 0.18.0
 
 ## What this repository is
 
@@ -69,7 +69,11 @@ project root. `CLAUDE.md` §1 makes those two MCP servers non-negotiable for thi
 setup skill is what puts them in place.
 
 *Manual fallback,* if you would rather wire it by hand: install the Quarkus Agents MCP with
-`/plugin marketplace add quarkusio/quarkus-agent-mcp` then `/plugin install quarkus-agent@quarkus-tools`;
+`/plugin marketplace add quarkusio/quarkus-agent-mcp` then `/plugin install quarkus-agent@quarkus-tools`
+— that plugin launches `jbang quarkus-agent-mcp@quarkusio`, which pins no JDK, so if the server never
+comes up, register it yourself with
+`claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`
+(see the [Bob note](#how-to-use-with-bob) on why the JDK flag matters);
 add context7 with `claude mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` (for higher rate limits
 `export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
 belongs on the command line); optionally install superpowers with
@@ -101,7 +105,7 @@ works for Codex too.)
 registers the **Quarkus Agents MCP** and **context7** MCP servers for Codex, and drops `AGENTS.md`
 into your project root. `AGENTS.md` §1 makes those two MCP servers non-negotiable for this stack.
 
-*Manual fallback:* add the Quarkus Agents MCP with `codex mcp add quarkus-agent -- jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner`;
+*Manual fallback:* add the Quarkus Agents MCP with `codex mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`;
 add context7 with `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` (for higher rate limits
 `export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
 belongs on the command line); install/enable the Superpowers plugin if you use it; and copy
@@ -120,27 +124,46 @@ first-class agent in the skills CLI, so the [Quick install](#quick-install--any-
 `.bob/skills/` for you — that is the recommended path.
 
 **Set up the prerequisites.** Run `/setup-agentic-scaffolding` — it verifies the toolchain,
-registers the **Quarkus Agents MCP** and **context7** MCP servers for Bob (via `.bob/mcp.json`),
-and drops `AGENTS.md` into your project root. If you already added `AGENTS.md` for Codex, the same
-file serves Bob — there is no separate `BOB.md`.
+registers the **Quarkus Agents MCP** and **context7** MCP servers for Bob, and drops `AGENTS.md`
+into your project root. If you already added `AGENTS.md` for Codex, the same file serves Bob — there
+is no separate `BOB.md`.
 
-*Manual fallback:* configure the MCP servers in `.bob/mcp.json` at your project root, or globally
-from the **MCP** tab in the Bob UI (**Edit Global MCP**) — which is the reliable route, because
-Bob's own docs disagree about the global file's path: the IDE docs say `~/.bob/mcp.json`, the Shell
-docs say `~/.bob/mcp_settings.json`. Either way the contents are the same:
+*Manual fallback:* register both servers with Bob's own CLI (Bob 2.0.0), which writes the file Bob
+actually reads:
+
+```
+bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner
+bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.0
+bob mcp list
+```
+
+The `--` is required: without it Bob parses `--java` as one of its own options and exits with
+`error: unknown option '--java'`. Use `-s workspace` to register in the current project instead —
+but at that scope the file must already exist, or the command dies with `ENOENT … .bob/mcp.json`;
+run `mkdir -p .bob && echo '{"mcpServers":{}}' > .bob/mcp.json` first. At global scope Bob creates
+the file and its directory for you.
+
+To write the JSON by hand instead, the global file is `~/.bob/settings/mcp.json` and the project
+file is `<project>/.bob/mcp.json` (a same-named server at project scope overrides global). Older
+Bob docs name `mcp_settings.json` in that same settings directory; Bob 2.0.0 treats it as legacy and
+migrates it **only when `mcp.json` does not yet exist**, so on a machine that already has `mcp.json`
+anything written to the legacy name is silently ignored. Contents either way:
 
 ```json
 {
   "mcpServers": {
-    "quarkus-agent": { "command": "jbang", "args": ["io.quarkus:quarkus-agent-mcp:1.2.5:runner"] },
+    "quarkus-agent": { "command": "jbang", "args": ["--java", "21+", "io.quarkus:quarkus-agent-mcp:1.2.5:runner"] },
     "context7":      { "command": "npx",   "args": ["-y", "@upstash/context7-mcp@4.0.0"] }
   }
 }
 ```
 
 (`jbang` must be on your PATH — install it with a package manager, e.g. `sdk install jbang` or
-`brew install jbang`. For higher rate limits `export CONTEXT7_API_KEY=…` in your environment rather
-than writing a literal key into the file; the server reads it from there.) If the skills CLI is
+`brew install jbang`. `--java 21+` is not optional: the MCP server is compiled for Java 21, and JBang
+resolves its own JDK — it falls back to its default, currently 17, whenever the process that spawned
+it hands over no `JAVA_HOME`, which is exactly what Bob and other GUI-launched clients do. For higher
+rate limits `export CONTEXT7_API_KEY=…` in your environment rather than writing a literal key into
+the file; the server reads it from there.) If the skills CLI is
 unavailable, the repository's fallback helper installs all three
 skills into `.bob/skills/` for you:
 
@@ -265,9 +288,10 @@ them with your agent's own MCP commands; nothing here does it for you.
 | The managed conventions block | `CLAUDE.md` / `AGENTS.md` in your project root |
 | The global conventions, if you did the [Advanced](#advanced--personal-use-optional-global-install) install | `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.bob/AGENTS.md` or `~/.bob/rules/<your-file>.md` |
 
-Three files `/setup-agentic-scaffolding` may have written are **kept**: `.cursor/mcp.json`,
-`opencode.json`, and `.bob/mcp.json`. Their entire content is the two MCP servers this boundary
-protects, so deleting them would remove exactly what you asked to keep.
+The MCP config files `/setup-agentic-scaffolding` may have written are **kept**: `.cursor/mcp.json`,
+`opencode.json`, and Bob's `.bob/mcp.json` (project) or `~/.bob/settings/mcp.json` (global). Their
+entire content is the two MCP servers this boundary protects, so deleting them would remove exactly
+what you asked to keep.
 
 ### 1. The skills
 
@@ -352,7 +376,7 @@ declares with it, so add them back at user scope:
 
 ```
 gemini extensions uninstall quarkus-agentic-scaffolding
-gemini mcp add -s user quarkus-agent jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner
+gemini mcp add -s user quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner
 gemini mcp add -s user context7 npx -y @upstash/context7-mcp@4.0.0
 gemini extensions list
 gemini mcp list

--- a/README.md
+++ b/README.md
@@ -68,21 +68,27 @@ registers the **Quarkus Agents MCP** and **context7** MCP servers, and drops `CL
 project root. `CLAUDE.md` §1 makes those two MCP servers non-negotiable for this stack, and the
 setup skill is what puts them in place.
 
-*Manual fallback,* if you would rather wire it by hand: install the Quarkus Agents MCP with
-`/plugin marketplace add quarkusio/quarkus-agent-mcp` then `/plugin install quarkus-agent@quarkus-tools`
-— that plugin launches `jbang quarkus-agent-mcp@quarkusio`, which pins no JDK, so if the server never
-comes up, register it yourself with
-`claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`.
-JBang picks its own JDK and defaults to 17 when the process that launched it exports no `JAVA_HOME`,
-and the server needs 21 — a login shell that sets `JAVA_HOME` hides this, the desktop app and the IDE
-extensions may not;
-add context7 with `claude mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` (for higher rate limits
+*Manual fallback,* if you would rather wire it by hand: register the Quarkus Agents MCP with the
+pinned command
+`claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`;
+add context7 with `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.0` (for higher rate limits
 `export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
 belongs on the command line); optionally install superpowers with
 `/plugin marketplace add obra/superpowers-marketplace` then
 `/plugin install superpowers@superpowers-marketplace`; and copy [`CLAUDE.md`](CLAUDE.md) into your
 project root yourself (Claude only auto-loads it from a project root or `~/.claude/`, so no plugin
 can ship it for you).
+
+Quarkus also ships the server as a Claude plugin — `/plugin marketplace add
+quarkusio/quarkus-agent-mcp` then `/plugin install quarkus-agent@quarkus-tools`. Two things to know
+before you pick that route over the command above. It launches `jbang quarkus-agent-mcp@quarkusio`,
+and that alias resolves `io.quarkus:quarkus-agent-mcp:RELEASE:runner`, so what runs is whatever was
+newest when the server started — two machines set up a week apart run different code. And it passes
+no `--java`: the alias *does* declare `java-version: 21+`, but JBang 0.125.x ignores that for a GAV
+script-ref, so the server runs on JBang's default JDK 17 and dies with `UnsupportedClassVersionError`
+unless whatever launched it happens to export a JDK 21+ `JAVA_HOME`. Use one route or the other, not
+both — the plugin's server and a `claude mcp add` entry are both named `quarkus-agent`, so uninstall
+the plugin (`/plugin uninstall quarkus-agent@quarkus-tools`) before registering by hand.
 
 **Try it.** Open your project and use a trigger phrase such as *"scaffold a new Quarkus +
 LangChain4j project"*, *"create a new AI service"*, or *"set up a new RAG pipeline"* —

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ setup skill is what puts them in place.
 `/plugin marketplace add quarkusio/quarkus-agent-mcp` then `/plugin install quarkus-agent@quarkus-tools`
 — that plugin launches `jbang quarkus-agent-mcp@quarkusio`, which pins no JDK, so if the server never
 comes up, register it yourself with
-`claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`
-(see the [Bob note](#how-to-use-with-bob) on why the JDK flag matters);
+`claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`.
+JBang picks its own JDK and defaults to 17 when the process that launched it exports no `JAVA_HOME`,
+and the server needs 21 — a login shell that sets `JAVA_HOME` hides this, the desktop app and the IDE
+extensions may not;
 add context7 with `claude mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` (for higher rate limits
 `export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
 belongs on the command line); optionally install superpowers with
@@ -141,13 +143,19 @@ The `--` is required: without it Bob parses `--java` as one of its own options a
 `error: unknown option '--java'`. Use `-s workspace` to register in the current project instead —
 but at that scope the file must already exist, or the command dies with `ENOENT … .bob/mcp.json`;
 run `mkdir -p .bob && echo '{"mcpServers":{}}' > .bob/mcp.json` first. At global scope Bob creates
-the file and its directory for you.
+the file and its directory for you. On a name that is already registered, `add` refuses
+(`Error: MCP server "quarkus-agent" already exists`) — to *replace* a stale entry use
+`bob mcp add-json -s global quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.5:runner"]}'`,
+which overwrites in place.
 
 To write the JSON by hand instead, the global file is `~/.bob/settings/mcp.json` and the project
 file is `<project>/.bob/mcp.json` (a same-named server at project scope overrides global). Older
 Bob docs name `mcp_settings.json` in that same settings directory; Bob 2.0.0 treats it as legacy and
 migrates it **only when `mcp.json` does not yet exist**, so on a machine that already has `mcp.json`
-anything written to the legacy name is silently ignored. Contents either way:
+anything written to the legacy name is silently ignored. If you set Bob up with a version of this
+guide before v0.18.0, also look for `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` — one directory
+above `settings/`, which is where we used to point you; Bob reads neither, so a registration sitting
+there has never loaded. Contents either way:
 
 ```json
 {
@@ -367,8 +375,9 @@ It removes only the three skills it installed, and only after reading each `SKIL
 is skipped with a warning rather than deleted. What the check cannot do is tell two identical
 declarations apart, so a skill of your own that *also* declares `name: audit-project` is
 indistinguishable from ours and **will** be removed. Move it aside before you run this. A symlinked
-skill is unlinked, not recursed into. `.bob/mcp.json`, `.bob/rules/`, and every other skill in
-`.bob/skills/` are left alone. Re-running it is a clean no-op. Skills load once per conversation, so
+skill is unlinked, not recursed into. Your MCP registration (`.bob/mcp.json` in a project,
+`~/.bob/settings/mcp.json` globally), `.bob/rules/`, and every other skill in `.bob/skills/` are
+left alone. Re-running it is a clean no-op. Skills load once per conversation, so
 **start a new conversation** in Bob afterwards.
 
 **Gemini CLI** — if you installed the extension, uninstalling it takes the two MCP servers it

--- a/ci/check-mcp-command-consistency.sh
+++ b/ci/check-mcp-command-consistency.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fails unless every published Quarkus Agents MCP registration carries the JDK pin
+# and the same pinned version.
+#
+# Why this gate exists: the launch command is hand-maintained in ~15 places across
+# README.md, the setup skill, and gemini-extension.json. check-version-consistency.sh
+# couples the artifact *version* across files and Renovate couples the *GAV*, but
+# nothing coupled the *command* — so `--java 21+` could be present in one copy and
+# missing in another with every other gate green. It has to be present in all of
+# them: JBang otherwise falls back to its default JDK (17 on 0.125.x) whenever the
+# process that spawns the server exports no JAVA_HOME, and the server needs 21.
+#
+# Historical files are out of scope on purpose: CHANGELOG.md and docs/ quote the old,
+# unpinned command as a record of what was fixed.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 - <<'PY'
+import glob, re, sys
+
+FILES = ["README.md", "gemini-extension.json"] + sorted(glob.glob("skills/*/SKILL.md"))
+GAV = re.compile(r"io\.quarkus:quarkus-agent-mcp:([0-9][^\s\"'`,\]]*):runner")
+# Flatten the punctuation that separates a JSON args array or a wrapped line, so a
+# markdown command, a JSON "args" list, and a quoted add-json payload all normalize
+# to the same token stream: ... --java 21+ io.quarkus:quarkus-agent-mcp:X:runner ...
+NOISE = re.compile(r"[\s\"',\[\]`]+")
+PINNED = re.compile(r"--java 21\+ $")
+
+unpinned, versions, total = [], set(), 0
+for path in FILES:
+    flat = NOISE.sub(" ", open(path, encoding="utf-8").read())
+    for m in GAV.finditer(flat):
+        total += 1
+        versions.add(m.group(1))
+        if not PINNED.search(flat[max(0, m.start() - 30):m.start()]):
+            unpinned.append((path, flat[max(0, m.start() - 60):m.end()].strip()))
+
+fail = False
+if unpinned:
+    fail = True
+    print("FAIL: a published registration is missing the `--java 21+` JDK pin.", file=sys.stderr)
+    print("      Every occurrence must read `jbang --java 21+ io.quarkus:...:runner`", file=sys.stderr)
+    print("      (or the JSON equivalent). Occurrences found without it:\n", file=sys.stderr)
+    for path, ctx in unpinned:
+        print(f"  {path}: …{ctx}", file=sys.stderr)
+if len(versions) > 1:
+    fail = True
+    print(f"\nFAIL: the pinned GAV version differs across files: {sorted(versions)}", file=sys.stderr)
+    print("      Renovate bumps them together; a partial bump is drift.", file=sys.stderr)
+if total == 0:
+    fail = True
+    print("FAIL: no Quarkus Agents MCP registration found at all — did a file move?", file=sys.stderr)
+if fail:
+    sys.exit(1)
+print(f"OK: {total} MCP registrations, all pinned to --java 21+ at version {versions.pop()}")
+PY

--- a/ci/test-uninstall-bob-skill.sh
+++ b/ci/test-uninstall-bob-skill.sh
@@ -93,8 +93,15 @@ H="$TMP/home"
 mkdir -p "$H"
 HOME="$H" "$INSTALL" --global >/dev/null
 for s in "${SKILLS[@]}"; do assert_exists "$H/.bob/skills/$s" "case6: global install $s"; done
+# The global MCP registration Bob 2.0.0 actually reads. --global sets BASE="$HOME",
+# so this file is inside the blast radius and the script promises to leave it alone.
+mkdir -p "$H/.bob/settings"
+printf '{"mcpServers":{}}\n' >"$H/.bob/settings/mcp.json"
 HOME="$H" "$UNINSTALL" --global >"$TMP/out6" 2>&1
 for s in "${SKILLS[@]}"; do assert_absent "$H/.bob/skills/$s" "case6: global remove $s"; done
+assert_exists "$H/.bob/settings/mcp.json" \
+  "case6: ~/.bob/settings/mcp.json survives (the global MCP boundary)"
+assert_exists "$H/.bob/skills" "case6: ~/.bob/skills/ itself survives"
 
 # --- Case 7: --help and a bad directory ---------------------------------------
 if "$UNINSTALL" --help >"$TMP/out7" 2>&1; then

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,12 +1,12 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {
     "quarkus-agent": {
       "command": "jbang",
-      "args": ["io.quarkus:quarkus-agent-mcp:1.2.5:runner"]
+      "args": ["--java", "21+", "io.quarkus:quarkus-agent-mcp:1.2.5:runner"]
     },
     "context7": {
       "command": "npx",

--- a/scripts/uninstall-bob-skill.sh
+++ b/scripts/uninstall-bob-skill.sh
@@ -8,10 +8,10 @@
 # filesystem rather than recording it. Deleting the directory IS the uninstall.
 #
 # Boundary — this removes the three skill directories and nothing else. .bob/ also holds
-# mcp.json (the Quarkus Agents MCP + context7 servers, which are shared with the rest of
-# your work and must survive), rules/, custom_modes.yaml, settings.json, hooks/, and
-# commands/. None are touched, and neither is .bob/skills/ itself, where your own skills
-# live.
+# the MCP registration (mcp.json at a project's .bob/, or settings/mcp.json under ~/.bob/ —
+# the Quarkus Agents MCP + context7 servers, which are shared with the rest of your work and
+# must survive), plus rules/, custom_modes.yaml, settings/, hooks/, and commands/. None are
+# touched, and neither is .bob/skills/ itself, where your own skills live.
 #
 # Two guards, because 'audit-project' is a generic enough name to collide with a skill you
 # wrote yourself:
@@ -31,8 +31,9 @@ usage() {
 uninstall-bob-skill.sh — remove this repository's skills from IBM Bob.
 
 Removes setup-agentic-scaffolding, scaffold-project, and audit-project from .bob/skills/.
-Leaves .bob/mcp.json (the Quarkus Agents MCP + context7 servers), .bob/rules/, and every
-other skill alone. Safe to re-run.
+Leaves your MCP registration (.bob/mcp.json in a project, ~/.bob/settings/mcp.json with
+--global — the Quarkus Agents MCP + context7 servers), .bob/rules/, and every other skill
+alone. Safe to re-run.
 
 Usage:
   uninstall-bob-skill.sh                    from ./.bob/skills/         (current directory)

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.17.0
+# Version: 0.18.0
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.17.0
+# Version: 0.18.0
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.17.0
+# Version: 0.18.0
 
 ## 1. When to use this skill
 
@@ -96,7 +96,7 @@ Rules for Phase A:
 
 Register two MCP servers through the running agent's own mechanism:
 
-- **quarkus-agent** — command `jbang`, args `io.quarkus:quarkus-agent-mcp:1.2.5:runner`
+- **quarkus-agent** — command `jbang`, args `--java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`
 - **context7** — command `npx`, args `-y @upstash/context7-mcp@4.0.0`. An API key raises the rate
   limits, but **do not put it on the command line**: over stdio the server falls back to the
   `CONTEXT7_API_KEY` environment variable whenever `--api-key` is absent, and a stdio server
@@ -116,8 +116,22 @@ reviewable change. Register the exact strings above — do not drop the version 
 Keeping them current is automation's job: Renovate watches these pins (`renovate.json`,
 `customManagers`) and opens a PR when upstream publishes a new release. Two notes on the pinned
 GAV: it is the same artifact the `quarkusio` catalog alias points at, only resolved to an explicit
-version, and a raw GAV drops the alias's `java-version: 21+` hint — which is moot here, because
-Phase A already requires JDK 25+.
+version, and a raw GAV drops the alias's `java-version: 21+` hint — which is why the registration
+carries `--java 21+` explicitly (see below).
+
+**`--java 21+` is part of the command, not decoration.** Do not drop it, and do not assume Phase A
+covers it. Phase A proves the *machine* has a JDK 25; it does not decide which JDK JBang picks.
+JBang resolves that itself, and it falls back to its own default JDK — 17 on JBang 0.125.x —
+whenever the process that spawned it exports no `JAVA_HOME` (GUI- and IDE-launched agents typically
+do not) or points at a JDK older than 21. Switching to the `quarkus-agent-mcp@quarkusio` alias does
+not save you either: the catalog entry does declare `java-version: 21+`, but JBang 0.125.x ignores
+it for a GAV `script-ref`, so the alias fails identically. The server is compiled for Java 21, so it
+then dies at boot with
+`UnsupportedClassVersionError: … class file version 65.0 … only recognizes … up to 61.0`, the client
+retries a few times and gives up, and the failure looks like "the MCP is not working" rather than a
+JDK mismatch. A terminal-launched agent that inherits a modern `JAVA_HOME` gets away without the
+flag by accident of the environment — which is precisely why the flag belongs in the command.
+`21+` is a floor, not a pin: JBang reuses an already-installed newer JDK instead of downloading 21.
 
 **Never handle a secret in plaintext.** Do not ask the user to paste an API key into the chat, do
 not embed a literal key in a command or a config file you write, and do not echo one back in
@@ -132,20 +146,20 @@ secrets by design (see the context7 note above), so "exact" is literal: what you
 
 | Agent | Register quarkus-agent + context7 | Verify | Live this session? |
 |---|---|---|---|
-| Claude Code | `claude mcp add -s user quarkus-agent -- jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.0` | `claude mcp list` | No — restart |
-| Codex CLI | `codex mcp add quarkus-agent -- jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` | `codex mcp list` | No — restart; sandbox may block network |
-| Gemini CLI | `gemini mcp add quarkus-agent jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `gemini mcp add context7 npx -y @upstash/context7-mcp@4.0.0` — **or** install this repo's Gemini extension, which already declares both servers | `gemini mcp list` | No — restart |
+| Claude Code | `claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.0` | `claude mcp list` | No — restart |
+| Codex CLI | `codex mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` | `codex mcp list` | No — restart; sandbox may block network |
+| Gemini CLI | `gemini mcp add quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `gemini mcp add context7 npx -y @upstash/context7-mcp@4.0.0` — **or** install this repo's Gemini extension, which already declares both servers | `gemini mcp list` | No — restart |
 | Cursor | Write `.cursor/mcp.json` with both servers (`mcpServers` map, same command/args) | Settings → MCP shows both; user **toggles them on** | GUI enable |
-| GitHub Copilot CLI | `copilot mcp add quarkus-agent -- jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `copilot mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` | `copilot mcp list` | **Yes** — live immediately |
+| GitHub Copilot CLI | `copilot mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `copilot mcp add context7 -- npx -y @upstash/context7-mcp@4.0.0` | `copilot mcp list` | **Yes** — live immediately |
 | opencode | Write `opencode.json` `mcp` key with both servers | `/mcp` in session | **Yes** — hot reload |
-| Bob (D3) | Write `.bob/mcp.json` (project) or `~/.bob/mcp.json` (global; the Bob Shell docs call it `mcp_settings.json` — prefer the UI's **Edit Global MCP**) with both servers | MCP tab in the Bob UI lists both | Reload in UI |
+| Bob (D3) | `bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.0` — the `--` is mandatory (see §5.1) | `bob mcp list` shows both, `stdio`, `global` | **Yes** — Bob restarts changed servers |
 
 The `.cursor/mcp.json`, `opencode.json`, and `.bob/mcp.json` map has the same shape everywhere:
 
 ```json
 {
   "mcpServers": {
-    "quarkus-agent": { "command": "jbang", "args": ["io.quarkus:quarkus-agent-mcp:1.2.5:runner"] },
+    "quarkus-agent": { "command": "jbang", "args": ["--java", "21+", "io.quarkus:quarkus-agent-mcp:1.2.5:runner"] },
     "context7":      { "command": "npx",   "args": ["-y", "@upstash/context7-mcp@4.0.0"] }
   }
 }
@@ -154,7 +168,30 @@ The `.cursor/mcp.json`, `opencode.json`, and `.bob/mcp.json` map has the same sh
 (opencode uses the top-level `mcp` key rather than `mcpServers`; keep the two server entries the
 same. `jbang` must be on PATH — that is Phase A's job.)
 
-### 5.1 Restart handoff
+### 5.1 Bob: which file, and the `--` separator
+
+Bob 2.0.0 ships `bob mcp add|list|remove`, so prefer the CLI over hand-writing JSON — it writes the
+file Bob actually reads and `bob mcp list` is a real verification. Three rules the CLI enforces:
+
+- **`--` before the server's own arguments is mandatory.** `bob mcp add … jbang --java 21+ <GAV>`
+  fails with `error: unknown option '--java'`, because Bob parses the flag as its own. With the
+  separator (`… jbang -- --java 21+ <GAV>`) the arguments land verbatim in the entry's `args`.
+- **`-s global` writes `~/.bob/settings/mcp.json`**, creating the file and directory if needed.
+  `-s workspace` (the default) writes `<project>/.bob/mcp.json` but does **not** create it — it exits
+  with `Fatal error: ENOENT … .bob/mcp.json`. Create the file first
+  (`mkdir -p .bob && echo '{"mcpServers":{}}' > .bob/mcp.json`) or use global scope.
+- **Never write `mcp_settings.json`.** Older Bob docs name that file in the same settings directory;
+  Bob 2.0.0 treats it as legacy and migrates it **only when `mcp.json` does not yet exist** (and it
+  says so: *"your global MCP configuration has been migrated to mcp.json"*). Where `mcp.json` is
+  already there — which one `bob mcp add -s global` is enough to cause — a registration written to
+  the legacy name is silently ignored, and the MCP looks registered while Bob never loads it. If you
+  find such a file, report it and register through the CLI instead.
+
+A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
+shallower one in the same workspace. When something still fails to start, Bob's own log is the
+evidence: `~/.bob/logs/shell/` — a `UnsupportedClassVersionError` there is the JDK trap from §5.
+
+### 5.2 Restart handoff
 
 In **Claude Code, Codex CLI, and Gemini CLI** a newly registered MCP server only loads on the **next
 session**. After registering and verifying it appears in the `mcp list` output, end with this
@@ -164,8 +201,10 @@ explicit handoff:
 > `/setup-agentic-scaffolding`.** The re-run is idempotent — it will skip everything already done and
 > confirm the Quarkus Agents MCP and context7 are now live. That re-run **is** the verification pass.
 
-**Cursor** needs a one-time GUI toggle (Settings → MCP). **Copilot CLI** and **opencode** pick the
-servers up immediately (opencode hot-reloads), so no restart is required for those two.
+**Cursor** needs a one-time GUI toggle (Settings → MCP). **Copilot CLI**, **opencode**, and **Bob**
+pick the servers up immediately — opencode hot-reloads, and Bob watches its `mcp.json` and restarts
+the servers whose entry changed (`Restarting changed servers` in `~/.bob/logs/shell/`) — so no
+restart is required for those three.
 
 ## 6. Superpowers (detect and guide — never auto-install)
 

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -68,6 +68,13 @@ Rules for Phase A:
 
 - **Report "already installed vs missing" honestly.** Show the probe output; never fabricate a
   version or a success.
+- **Give JBang a 21+ JDK here, not at the first MCP start.** Once JBang is present, check
+  `jbang jdk list`; if nothing 21 or newer is installed, run `jbang jdk install 21` (with approval —
+  it is a JDK-sized download). Skip this and JBang does that download *inside* the MCP handshake the
+  first time a client starts the server: it fetches a full JDK before the first protocol byte, the
+  client's `initialize` times out, and the user reads it as "the MCP is broken". Record
+  `command -v jbang`'s absolute path while you are here — §5 needs it for clients that spawn the
+  server without your PATH.
 - **Install only what the user approves**, one tool at a time, and **re-probe** after each install
   to confirm.
 - **Never pipe a downloaded script into a shell — not even with approval.** A package manager is
@@ -166,7 +173,27 @@ The `.cursor/mcp.json`, `opencode.json`, and `.bob/mcp.json` map has the same sh
 ```
 
 (opencode uses the top-level `mcp` key rather than `mcpServers`; keep the two server entries the
-same. `jbang` must be on PATH — that is Phase A's job.)
+same. Bob is not in that list — its paths and its CLI are §5.1.)
+
+**Verify the stored command, not just the name.** Each `mcp list` above prints the command its
+servers will run; that string is the verification. "A server called `quarkus-agent` is listed" proves
+nothing — an entry left by an earlier release of this skill, by the upstream Quarkus Claude plugin,
+or by hand satisfies it while running an unpinned `jbang quarkus-agent-mcp@quarkusio`. Read the
+command back, compare it to `jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner`, and treat a
+mismatch as a **repair**, not a skip — that is what makes the idempotent re-run worth anything.
+Repair means replacing the entry, never adding a second one under the same name: `bob mcp add-json`
+overwrites in place (§5.1), and elsewhere remove then re-add with the pinned command
+(`claude mcp remove -s user quarkus-agent`; for the other CLIs check `<cli> mcp --help` for the
+removal form rather than guessing it). Show the user the before and after strings.
+
+**`jbang` must be resolvable by the process that spawns the server — which is not the shell Phase A
+probed.** A GUI- or IDE-launched client is started by launchd (or systemd) with a minimal PATH: on
+macOS `launchctl getenv PATH` is typically empty, so the child gets `/usr/bin:/bin:/usr/sbin:/sbin`,
+and none of `sdk install jbang` (`~/.sdkman/…`), `brew install jbang` (`/opt/homebrew/bin`), or the
+upstream installer (`~/.jbang/bin`) puts `jbang` there. The symptom is `spawn jbang ENOENT` before
+`--java 21+` gets a chance to matter, and Phase A cannot see it — its probe runs in your login shell.
+When a client fails that way, register the **absolute path** from `command -v jbang` as the command,
+with the same arguments.
 
 ### 5.1 Bob: which file, and the `--` separator
 
@@ -209,6 +236,14 @@ three the CLI enforces, one Bob's loader does.
 A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
 shallower one in the same workspace. When something still fails to start, Bob's own log is the
 evidence: `~/.bob/logs/shell/` — a `UnsupportedClassVersionError` there is the JDK trap from §5.
+
+**No `bob` on PATH?** Probe with `command -v bob` before you plan the registration: a Bob-IDE-only
+machine has no CLI, and the whole route above is unavailable. Then hand-write the file — global
+`~/.bob/settings/mcp.json`, project `<project>/.bob/mcp.json` — read-modify-write so the user's other
+servers survive, with the entries from §5 including `--java 21+`. Verify in the UI's **MCP** tab,
+which lists what Bob actually loaded; that is the one verification that needs no binary. Every rule
+above still applies: not the legacy name, not a truncating write, and Bob reloads changed servers on
+its own.
 
 ### 5.2 Restart handoff
 

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -260,6 +260,14 @@ pick the servers up immediately — opencode hot-reloads, and Bob watches its `m
 the servers whose entry changed (`Restarting changed servers` in `~/.bob/logs/shell/`) — so no
 restart is required for those three.
 
+**Bob still needs a new conversation, for a different reason.** The restart above is the server
+process only; Bob loads skills and the conventions file **once per conversation**, so a run that also
+wrote `AGENTS.md` (Phase C) ends in a conversation that has not read it. Close with:
+
+> The MCP servers are live in this conversation. `AGENTS.md` and the skills load once per
+> conversation, so **start a new conversation** in Bob before running `/scaffold-project` — otherwise
+> the conventions are not in context and §1's tooling rule will stop the work.
+
 ## 6. Superpowers (detect and guide — never auto-install)
 
 `superpowers` skills are used wherever applicable in this stack, but they are a **third-party

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -176,6 +176,13 @@ file Bob actually reads and `bob mcp list` is a real verification. Three rules t
 - **`--` before the server's own arguments is mandatory.** `bob mcp add … jbang --java 21+ <GAV>`
   fails with `error: unknown option '--java'`, because Bob parses the flag as its own. With the
   separator (`… jbang -- --java 21+ <GAV>`) the arguments land verbatim in the entry's `args`.
+- **`add` never updates an existing entry — `add-json` does.** On a name that is already registered,
+  `bob mcp add` exits 1 with `Error: MCP server "…" already exists in …` and leaves the old entry
+  untouched, so an idempotent re-run cannot repair a stale registration (an unpinned command, say)
+  through it. Use `bob mcp add-json -s <scope> quarkus-agent '{"command":"jbang","args":["--java",
+  "21+","io.quarkus:quarkus-agent-mcp:1.2.5:runner"]}'`, which overwrites in place — still the CLI,
+  so the file Bob reads stays the one being written. Show the user the current entry and confirm
+  before overwriting; `bob mcp remove` then `add` works too, but loses the entry if the add fails.
 - **`-s global` writes `~/.bob/settings/mcp.json`**, creating the file and directory if needed.
   `-s workspace` (the default) writes `<project>/.bob/mcp.json` but does **not** create it — it exits
   with `Fatal error: ENOENT … .bob/mcp.json`. Create the file first
@@ -184,8 +191,11 @@ file Bob actually reads and `bob mcp list` is a real verification. Three rules t
   Bob 2.0.0 treats it as legacy and migrates it **only when `mcp.json` does not yet exist** (and it
   says so: *"your global MCP configuration has been migrated to mcp.json"*). Where `mcp.json` is
   already there — which one `bob mcp add -s global` is enough to cause — a registration written to
-  the legacy name is silently ignored, and the MCP looks registered while Bob never loads it. If you
-  find such a file, report it and register through the CLI instead.
+  the legacy name is silently ignored, and the MCP looks registered while Bob never loads it. Check
+  `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` as well — one directory **above** the settings
+  directory, where releases of this skill before v0.18.0 told agents to write. Bob reads neither and
+  migrates neither, so a machine set up by an earlier run may hold a registration there that has
+  never loaded. If you find any of the three, report it and register through the CLI instead.
 
 A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
 shallower one in the same workspace. When something still fails to start, Bob's own log is the

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -170,9 +170,19 @@ same. `jbang` must be on PATH — that is Phase A's job.)
 
 ### 5.1 Bob: which file, and the `--` separator
 
-Bob 2.0.0 ships `bob mcp add|list|remove`, so prefer the CLI over hand-writing JSON — it writes the
-file Bob actually reads and `bob mcp list` is a real verification. Three rules the CLI enforces:
+Bob 2.0.0 ships `bob mcp add|add-json|list|remove`, so prefer the CLI over hand-writing JSON — it
+writes the file Bob actually reads and `bob mcp list` is a real verification. Four things to know:
+three the CLI enforces, one Bob's loader does.
 
+- **Probe for the legacy file BEFORE the first `add` — this ordering is load-bearing.** Bob migrates
+  `~/.bob/settings/mcp_settings.json` into `mcp.json` **only when `mcp.json` does not yet exist**.
+  `bob mcp add -s global` creates `mcp.json`, so registering first blocks that migration
+  permanently: on a machine whose global config still lives in the legacy file, our two servers land
+  in a fresh `mcp.json` and **every other server the user configured silently stops loading**. So:
+  if the legacy file exists and `mcp.json` does not, have the user start Bob once and let it migrate
+  (it announces *"your global MCP configuration has been migrated to mcp.json"*), confirm the
+  servers survived, and only then register. Never resolve this by copying files around yourself
+  without showing the user both files first.
 - **`--` before the server's own arguments is mandatory.** `bob mcp add … jbang --java 21+ <GAV>`
   fails with `error: unknown option '--java'`, because Bob parses the flag as its own. With the
   separator (`… jbang -- --java 21+ <GAV>`) the arguments land verbatim in the entry's `args`.
@@ -185,17 +195,16 @@ file Bob actually reads and `bob mcp list` is a real verification. Three rules t
   before overwriting; `bob mcp remove` then `add` works too, but loses the entry if the add fails.
 - **`-s global` writes `~/.bob/settings/mcp.json`**, creating the file and directory if needed.
   `-s workspace` (the default) writes `<project>/.bob/mcp.json` but does **not** create it — it exits
-  with `Fatal error: ENOENT … .bob/mcp.json`. Create the file first
-  (`mkdir -p .bob && echo '{"mcpServers":{}}' > .bob/mcp.json`) or use global scope.
-- **Never write `mcp_settings.json`.** Older Bob docs name that file in the same settings directory;
-  Bob 2.0.0 treats it as legacy and migrates it **only when `mcp.json` does not yet exist** (and it
-  says so: *"your global MCP configuration has been migrated to mcp.json"*). Where `mcp.json` is
-  already there — which one `bob mcp add -s global` is enough to cause — a registration written to
-  the legacy name is silently ignored, and the MCP looks registered while Bob never loads it. Check
-  `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` as well — one directory **above** the settings
-  directory, where releases of this skill before v0.18.0 told agents to write. Bob reads neither and
-  migrates neither, so a machine set up by an earlier run may hold a registration there that has
-  never loaded. If you find any of the three, report it and register through the CLI instead.
+  with `Fatal error: ENOENT … .bob/mcp.json`. Seed it **only when it is missing**, because `>`
+  truncates and an existing file holds the user's other servers:
+  `[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }` — or
+  just use global scope, where Bob creates the file itself.
+- **Never write `mcp_settings.json` yourself** (Bob's loader, not the CLI). A registration written
+  there on a machine that already has `mcp.json` is silently ignored — it looks registered and Bob
+  never loads it. Check `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` too: one directory **above**
+  the settings directory, where releases of this skill before v0.18.0 told agents to write. Bob reads
+  neither and migrates neither, so a machine set up by an earlier run may hold a registration there
+  that has never loaded. If you find one, report it and register through the CLI instead.
 
 A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
 shallower one in the same workspace. When something still fails to start, Bob's own log is the

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.17.0
+# Version: 0.18.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.17.0
+# Version: 0.18.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Two bugs in what this artifact publishes, both surfaced by a real "the Quarkus Agents MCP is not working in Bob" incident.

## Bug 1 — the published registration pinned no JDK

We shipped `jbang io.quarkus:quarkus-agent-mcp:1.2.5:runner` in eight places, and setup §5 justified the missing JDK hint with *"moot here, because Phase A already requires JDK 25+"*. That reasoning is the bug: Phase A proves the **machine** has a JDK 25, but JBang resolves its own JDK and falls back to its default — 17 on JBang 0.125.x — whenever the spawning process exports no `JAVA_HOME`, which GUI- and IDE-launched agents do not. The server is compiled for Java 21, so it died at boot with `UnsupportedClassVersionError: … class file version 65.0 … up to 61.0`, the client retried and gave up, and it read as "the MCP is broken".

Verified by MCP `initialize` handshake against 1.2.5:

| command | environment | result |
|---|---|---|
| `jbang <GAV>` (the old one) | `JAVA_HOME=25` | **PASS** — why we never saw it |
| `jbang <GAV>` (the old one) | no `JAVA_HOME` | **FAIL** `UnsupportedClassVersionError` |
| `jbang --java 21 <GAV>` | no `JAVA_HOME` | PASS |
| `jbang --java 21+ <GAV>` | no `JAVA_HOME` | PASS |
| `jbang --java 21+ <GAV>` | `JAVA_HOME=25` | PASS |

The `quarkus-agent-mcp@quarkusio` alias is not an escape hatch: the catalog entry does declare `java-version: 21+`, but JBang 0.125.x ignores it for a GAV `script-ref` and fails identically (also verified). `21+` is a floor rather than a pin, so a machine already on 25 reuses it instead of downloading JDK 21.

Fixed in the four `mcp add` rows + JSON snippet of the setup skill, the Codex/Gemini/Bob commands and both snippets in `README.md`, and `gemini-extension.json`. Setup §5 now carries an explicit **"`--java 21+` is part of the command, not decoration"** rule instead of the wrong rationale. Renovate still resolves — its `matchStrings` anchor on the GAV, which the flag precedes.

## Bug 2 — Bob's global MCP file was documented at a path Bob never reads

We published `~/.bob/mcp.json` (hedging toward `mcp_settings.json`). Bob 2.0.0's own constants:

```
MCP_WORKSPACE_FILENAME     = "mcp.json"           → <project>/.bob/mcp.json      correct
MCP_GLOBAL_FILENAME        = "mcp.json"           → ~/.bob/settings/mcp.json     we had it wrong
MCP_LEGACY_GLOBAL_FILENAME = "mcp_settings.json"  → migrated only if mcp.json is absent
```

So a registration written to the legacy name on a machine that already has `mcp.json` is **silently ignored**: setup reports success and Bob never loads the server. That is exactly what had happened on the machine where this was found.

Bob registration therefore moves from hand-written JSON to `bob mcp add -s global … ` with `bob mcp list` as verification. Two CLI behaviors, reproduced in a scratch workspace: the `--` separator is mandatory (without it Bob exits `error: unknown option '--java'`), and `-s workspace` does **not** create `.bob/mcp.json` (`Fatal error: ENOENT`). Bob also watches the file and restarts changed servers, so its "Live this session?" cell moves from "Reload in UI" to yes. New §5.1 documents all of it; the restart handoff becomes §5.2.

The README additionally notes that the upstream Claude plugin (`quarkus-agent@quarkus-tools`) launches `jbang quarkus-agent-mcp@quarkusio` with no pin, and points at the pinned `claude mcp add` as the fix.

## Verification

```
check-version-consistency.sh        OK: version 0.18.0 consistent across 9 files
check-conventions-parity.sh         OK (twins + both templates/ seeds re-copied)
test-conventions-block-removal.sh   OK (15 fixtures)
test-uninstall-bob-skill.sh         OK (3 skills, 7 cases)
markdownlint-cli2                   0 issues in 19 files
```

Every command published here was executed on a real machine — MCP handshakes for the JBang matrix, `bob mcp add`/`list` for the Bob rows, the Bob 2.0.0 bundle for the path constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)