### PR TITLE
chore: cut v0.20.1 — changelog for the #25/#17 doc fixes, Unreleased section for contributors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.20.0
+# Version: 0.20.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.20.1 — 2026-08-26
+- **The README no longer presents `-s workspace` as opt-in on `bob mcp add`.** Workspace scope is
+  Bob's own default, so dropping the `-s global` flag from the published command registers in the
+  current project — and dies with `ENOENT … .bob/mcp.json` when that file is missing. The
+  paragraph now states the default the way the setup skill's §5.1 always has. (#25, PR #32 by
+  @matheusandre1)
+- **The five consistency nits deferred from the v0.17.0 reviews are closed.** The Bob install and
+  uninstall fences mark their three forms as alternatives, not a sequence; the conventions-removal
+  recipe's optional file drop got its own `# 4b.` comment; fixture D1's label now matches D2/D3
+  (`ACCEPTED residual`); `CONTRIBUTING.md` carries the IBM-internal qualifier the README already
+  had; and the Gemini CLI row states that `gemini mcp add` defaults to `--scope project`. (#17,
+  PR #33 by @matheusandre1)
+- **Contributors no longer have to guess the next version.** `CONTRIBUTING.md` step 5 asked every
+  PR to bump the version headers and name its own changelog section — unknowable from a branch,
+  and two concurrent PRs would conflict on all nine headers. External changes are now recorded
+  under a `## Unreleased` heading in this file (created when absent), and the maintainer renames
+  that section and bumps the headers in the release commit.
+
 ## v0.20.0 — 2026-08-21
 - **Security-audit hardening: the skills' instruction text now states its trust posture
   explicitly, and the one remaining download-and-execute path is gone.** Driven by the skills.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.20.0
+# Version: 0.20.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,10 @@ against these tools first.
 3. Make the change in the right place (`CLAUDE.md` / `AGENTS.md` vs `SKILL.md` vs a template).
 4. If you touch a template, **validate it still builds** — see
    [`docs/VALIDATING-TEMPLATES.md`](docs/VALIDATING-TEMPLATES.md).
-5. **Bump the version** (semver) in the version headers of `README.md`, `CLAUDE.md`,
-   `AGENTS.md`, the three `skills/*/SKILL.md` files, `.claude-plugin/plugin.json`,
-   `.codex-plugin/plugin.json`, and `gemini-extension.json`, and add a `CHANGELOG.md` entry.
+5. **Record the change in `CHANGELOG.md` under a `## Unreleased` heading** at the top of the
+   file, creating that section if it is not there. Do not pick a version number and do not touch
+   the version headers: with concurrent PRs the next version is unknowable from a branch, so the
+   bump is the maintainer's job at release time (see [Versioning](#versioning)).
 6. Open a PR that links the issue and summarizes the evidence.
 
 ### Evidence bar for conventions and templates
@@ -80,7 +81,9 @@ Conventions and templates should reflect how real Quarkus + LangChain4j systems 
 This artifact uses semantic versioning. Keep the version header identical across `README.md`,
 `CLAUDE.md`, `AGENTS.md`, the three `skills/*/SKILL.md` files, `.claude-plugin/plugin.json`,
 `.codex-plugin/plugin.json`, and `gemini-extension.json` (nine files, enforced by
-`ci/check-version-consistency.sh`), and record every change in `CHANGELOG.md`. A version bump also
+`ci/check-version-consistency.sh`), and record every change in `CHANGELOG.md` — contributors add
+theirs under `## Unreleased`, and the maintainer renames that section to the new version and bumps
+all nine headers in the same release commit. A version bump also
 reaches the two seed copies the setup skill ships —
 `skills/setup-agentic-scaffolding/templates/conventions-{CLAUDE,AGENTS}.md` — so re-copy the root
 files over them; `ci/check-conventions-parity.sh` fails on the drift otherwise.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.20.0
+# Version: 0.20.1
 
 ## What this repository is
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.20.0
+# Version: 0.20.1
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.20.0
+# Version: 0.20.1
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.20.0
+# Version: 0.20.1
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.20.0
+# Version: 0.20.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.20.0
+# Version: 0.20.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Release commit for v0.20.1:

- **CHANGELOG v0.20.1** recording the two merged community fixes: the README `bob mcp add` scope-default correction (#25, #32) and the five v0.17.0 consistency nits (#17, #33), both by @matheusandre1.
- **Version bump 0.20.0 → 0.20.1** across the nine headers plus the two conventions seed copies.
- **CONTRIBUTING step 5 reworked**: contributors now record changes under a `## Unreleased` changelog section instead of guessing the next version; the maintainer renames the section and bumps the nine headers in the release commit. The Versioning section states the same flow.

All gates pass locally: version-consistency, conventions-parity, mcp-command-consistency, both behavior tests, markdownlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)