### PR TITLE
docs: comment all three forms in the Bob install/uninstall fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## Unreleased
+- **Pasting a whole Bob fence now runs nothing — all three forms are commented.** The v0.20.1
+  "Pick one" comment left the first form active, so uncommenting `--global` and pasting the block
+  still ran the `<cwd>` form as well. Both fences (install and uninstall, keeping the symmetry
+  issue #17 asked for) now comment every form, so "uncomment the one you want" applies to each of
+  them; the uninstall fence's read-only `ls` verify line stays active.
+
 ## v0.20.1 — 2026-08-26
 - **The README no longer presents `-s workspace` as opt-in on `bob mcp add`.** Workspace scope is
   Bob's own default, so dropping the `-s global` flag from the published command registers in the

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ skills into `.bob/skills/` for you:
 
 ```
 # Pick one — the three forms are alternatives, not a sequence; uncomment the one you want
-./scripts/install-bob-skill.sh                     # into <cwd>/.bob/skills/
+# ./scripts/install-bob-skill.sh                   # into <cwd>/.bob/skills/
 # ./scripts/install-bob-skill.sh /path/to/project  # into that project's .bob/skills/
 # ./scripts/install-bob-skill.sh --global          # into ~/.bob/skills/
 ```
@@ -391,7 +391,7 @@ directory is the whole uninstall.
 
 ```
 # Pick one — the three forms are alternatives, not a sequence; uncomment the one you want
-./scripts/uninstall-bob-skill.sh                     # from <cwd>/.bob/skills/
+# ./scripts/uninstall-bob-skill.sh                   # from <cwd>/.bob/skills/
 # ./scripts/uninstall-bob-skill.sh /path/to/project  # from that project's .bob/skills/
 # ./scripts/uninstall-bob-skill.sh --global          # from ~/.bob/skills/
 ls .bob/skills/                                      # verify; and: ls ~/.bob/skills/


### PR DESCRIPTION
Closes the minor follow-up from the #33 review: the "Pick one" comment left the first form active, so uncommenting `--global` and pasting the whole block still ran the `<cwd>` form as well.

- Both fences (install ~line 199, uninstall ~line 391) now comment every form, keeping the symmetry issue #17 asked for; "uncomment the one you want" applies to each of them.
- The uninstall fence's read-only `ls` verify line stays active.
- Recorded in `CHANGELOG.md` under `## Unreleased` — first use of the new CONTRIBUTING step 5 flow.

Validated locally: `ci/test-conventions-block-removal.sh`, `ci/test-uninstall-bob-skill.sh`, and markdownlint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)