### PR TITLE
docs: clarify bob mcp registration scope and trade-offs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this artifact are documented here. This project adheres t
 versioning.
 
 ## Unreleased
+- **Bob's `-s global` MCP registration is now a stated choice, not a silent default.** The setup
+  skill's §5 Bob row and §5.1, and the README's *How to use with Bob*, register with `-s global` —
+  which writes `~/.bob/settings/mcp.json` and applies to every workspace on the machine — without
+  saying so, while the equivalent decision for the conventions file carries an explicit trade-off
+  paragraph. All three spots now state the machine-wide scope and why it is the default (the MCPs
+  are tools, not conventions, and re-registering per project is friction), and offer `-s workspace`
+  to users who mix stacks — with the ENOENT seeding caveat §5.1 already documents. (#19)
 - **Pasting a whole Bob fence now runs nothing — all three forms are commented.** The v0.20.1
   "Pick one" comment left the first form active, so uncommenting `--global` and pasting the block
   still ran the `<cwd>` form as well. Both fences (install and uninstall, keeping the symmetry

--- a/README.md
+++ b/README.md
@@ -146,11 +146,18 @@ bob mcp list
 ```
 
 The `--` is required: without it Bob parses `--java` as one of its own options and exits with
-`error: unknown option '--java'`. The `-s global` above is deliberate: Bob's own default is
-`-s workspace`, so dropping the flag does not mean "no scope" — it registers in the current project,
-and at that scope the file must already exist or the command dies with `ENOENT … .bob/mcp.json`.
-Seed it **only if it is missing** — `>` truncates, and an existing file holds registrations worth
-keeping:
+`error: unknown option '--java'`.
+
+**Trade-off (stated explicitly):** `-s global` writes `~/.bob/settings/mcp.json` and registers both
+servers for **every workspace on the machine**, not just this project. That is the default here
+because these MCP servers are tools, not conventions — they answer Quarkus and library questions
+and change nothing in projects that never call them — and re-registering them per project is
+friction. If you mix stacks and want nothing of this artifact reaching your other work, register at
+workspace scope instead: `-s workspace` is Bob's own default, so dropping the flag means the same
+thing — it registers in the current project only. One caveat at that scope: Bob does not create
+`<project>/.bob/mcp.json`, so the command dies with `ENOENT … .bob/mcp.json` when the file is
+missing. Seed it **only if it is missing** — `>` truncates, and an existing file holds
+registrations worth keeping:
 
 ```
 [ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -166,7 +166,7 @@ secrets by design (see the context7 note above), so "exact" is literal: what you
 | Cursor | Write `.cursor/mcp.json` with both servers (`mcpServers` map, same command/args) | Settings → MCP shows both; user **toggles them on** | GUI enable |
 | GitHub Copilot CLI | `copilot mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `copilot mcp add context7 -- npx -y @upstash/context7-mcp@4.0.3` | `copilot mcp list` | **Yes** — live immediately |
 | opencode | Write `opencode.json` `mcp` key with both servers | `/mcp` in session | **Yes** — hot reload |
-| Bob (D3) | `bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.3` — the `--` is mandatory (see §5.1) | `bob mcp list` shows both, `stdio`, `global` | **Yes** — Bob restarts changed servers |
+| Bob (D3) | `bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.5:runner` · `bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.3` — the `--` is mandatory, and `-s global` is machine-wide: state that to the user and offer `-s workspace` to stack-mixers (both §5.1) | `bob mcp list` shows both, `stdio`, `global` (or `workspace`) | **Yes** — Bob restarts changed servers |
 
 The `.cursor/mcp.json`, `opencode.json`, and `.bob/mcp.json` map has the same shape everywhere:
 
@@ -232,12 +232,18 @@ three the CLI enforces, one Bob's loader does.
   "21+","io.quarkus:quarkus-agent-mcp:1.2.5:runner"]}'`, which overwrites in place — still the CLI,
   so the file Bob reads stays the one being written. Show the user the current entry and confirm
   before overwriting; `bob mcp remove` then `add` works too, but loses the entry if the add fails.
-- **`-s global` writes `~/.bob/settings/mcp.json`**, creating the file and directory if needed.
-  `-s workspace` (the default) writes `<project>/.bob/mcp.json` but does **not** create it — it exits
-  with `Fatal error: ENOENT … .bob/mcp.json`. Seed it **only when it is missing**, because `>`
-  truncates and an existing file holds the user's other servers:
-  `[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }` — or
-  just use global scope, where Bob creates the file itself.
+- **`-s global` is a scope decision — state it, never make it silently.** It writes
+  `~/.bob/settings/mcp.json` (creating file and directory if needed) and registers the servers for
+  **every workspace on the machine**, not just this project. That is this skill's default because
+  the servers are tools, not conventions — they change nothing in projects that never call them —
+  and re-registering per project is friction; but tell the user that is the scope they are getting,
+  and offer `-s workspace` to anyone who mixes stacks and wants the registration confined to the
+  current project. `-s workspace` (Bob's own default) writes `<project>/.bob/mcp.json` but does
+  **not** create it — it exits with `Fatal error: ENOENT … .bob/mcp.json`. Seed it **only when it
+  is missing**, because `>` truncates and an existing file holds the user's other servers:
+  `[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }`. At
+  workspace scope the verify column reads `workspace`, and the legacy-migration probe in the first
+  bullet still applies before any *global* add.
 - **Never write `mcp_settings.json` yourself** (Bob's loader, not the CLI). A registration written
   there on a machine that already has `mcp.json` is silently ignored — it looks registered and Bob
   never loads it. Check `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` too: one directory **above**


### PR DESCRIPTION
Closes: #19 

- Added the scope trade-off for the global `-s` flag in `mcp-bob`, which prevents the overlap section from losing its silent behavior.