### PR TITLE
test: cover dangling-symlink and bare-invocation branches of uninstall-bob-skill.sh

### DIFF
--- a/ci/test-uninstall-bob-skill.sh
+++ b/ci/test-uninstall-bob-skill.sh
@@ -76,6 +76,7 @@ printf 'x\n' >"$N/.bob/skills/scaffold-project/templates/leftover.txt"
 "$UNINSTALL" "$N" >"$TMP/out4" 2>&1 || true
 assert_exists "$N/.bob/skills/scaffold-project/templates/leftover.txt" \
   "case4: directory without SKILL.md is left in place"
+assert_grep "$TMP/out4" "SKILL.md declares '<none>'" "case4: warns about missing SKILL.md"
 
 # --- Case 5: symlinked skill - unlink the link, never recurse into the target --
 S="$TMP/symlinked"
@@ -102,6 +103,7 @@ for s in "${SKILLS[@]}"; do assert_absent "$H/.bob/skills/$s" "case6: global rem
 assert_exists "$H/.bob/settings/mcp.json" \
   "case6: ~/.bob/settings/mcp.json survives (the global MCP boundary)"
 assert_exists "$H/.bob/skills" "case6: ~/.bob/skills/ itself survives"
+assert_grep "$TMP/out6" "Removed 'setup-agentic-scaffolding' from:" "case6: output reports removal"
 
 # --- Case 7: --help and a bad directory ---------------------------------------
 if "$UNINSTALL" --help >"$TMP/out7" 2>&1; then
@@ -109,14 +111,44 @@ if "$UNINSTALL" --help >"$TMP/out7" 2>&1; then
 else
   fail "case7: --help exits 0"
 fi
-if "$UNINSTALL" "$TMP/does-not-exist" >"$TMP/out8" 2>&1; then
+assert_grep "$TMP/out7" "uninstall-bob-skill.sh" "case7: --help prints usage text"
+if "$UNINSTALL" "$TMP/does-not-exist" >"$TMP/out7b" 2>&1; then
   fail "case7: a missing target directory must fail"
 else
   pass "case7: a missing target directory fails"
 fi
 
+# --- Case 8: dangling symlink - ownership unverifiable, so left alone ----------
+# Intended behavior: ownership cannot be verified through a broken link, so the script
+# leaves the dangling symlink in place rather than deleting blindly.
+D="$TMP/dangling"
+mkdir -p "$D/.bob/skills"
+# $TMP/dangling-target-must-not-exist is intentionally never created — that is what makes
+# this a dangling symlink. Do not create it anywhere else in this file.
+ln -s "$TMP/dangling-target-must-not-exist" "$D/.bob/skills/audit-project"
+"$UNINSTALL" "$D" >"$TMP/out8" 2>&1 || true
+assert_exists "$D/.bob/skills/audit-project" "case8: dangling symlink survives"
+assert_grep "$TMP/out8" "SKILL.md declares '<none>'" "case8: warns about unverifiable dangling symlink"
+assert_grep "$TMP/out8" "Skipped 'setup-agentic-scaffolding': not installed" \
+  "case8: other skills reported not installed"
+assert_grep "$TMP/out8" "Skipped 'scaffold-project': not installed" \
+  "case8: other skills reported not installed (scaffold-project)"
+
+# --- Case 9: bare invocation uses $PWD ----------------------------------------
+# The outer $PWD is the repo root (set at line 7). Run entirely inside a subshell
+# that cd's into a temp directory — never call "$UNINSTALL" with no arguments outside
+# this subshell, or it would operate on the repo's own .bob/skills/.
+mkdir -p "$TMP/bare"
+"$INSTALL" "$TMP/bare" >/dev/null
+for s in "${SKILLS[@]}"; do assert_exists "$TMP/bare/.bob/skills/$s" "case9: installed $s"; done
+( cd "$TMP/bare" && "$UNINSTALL" ) >"$TMP/out9" 2>&1
+for s in "${SKILLS[@]}"; do
+  assert_absent "$TMP/bare/.bob/skills/$s" "case9: bare invocation removed $s"
+  assert_grep "$TMP/out9" "Removed '$s' from:" "case9: reported removal of $s"
+done
+
 if [[ "$failures" == 0 ]]; then
-  echo "OK: uninstall-bob-skill.sh behaves ($(( ${#SKILLS[@]} )) skills, 7 cases)"
+  echo "OK: uninstall-bob-skill.sh behaves ($(( ${#SKILLS[@]} )) skills, 9 cases)"
 else
   echo "FAIL: $failures assertion(s) failed" >&2
   exit 1


### PR DESCRIPTION
Closes #16

## What this changes

Only `ci/test-uninstall-bob-skill.sh` is modified. `scripts/uninstall-bob-skill.sh` is untouched — both behaviors being tested are **already correct**; the issue was that nothing pinned them, so a future refactor could silently break them.

---

## Case 8 — dangling symlink is left alone

**The behavior being pinned:**
A symlink at a skill path whose target no longer exists gets past the `-e` existence check (the `[[ ! -e "$DEST" && ! -L "$DEST" ]]` guard is false for any symlink, live or dangling). It then hits the ownership check: `-f "$DEST/SKILL.md"` is false through a broken link, so `DECLARED` stays empty, and the skip fires:

```
Skipped 'audit-project': SKILL.md declares '<none>', not ours — left in place
```

This is the **conservative** choice: if ownership cannot be verified, don't delete. A comment in the new test block states this explicitly so the next reader doesn't treat it as an oversight.

**How the case is constructed:**
- Creates `$TMP/dangling/.bob/skills/audit-project` as a symlink pointing at `$TMP/dangling-target-must-not-exist`.
- The target path is **intentionally never created** anywhere in the file. The name makes this invariant self-documenting and avoids accidental collision with any other case's fixtures.
- Runs the uninstaller with `|| true` — required because `set -euo pipefail` at the top of the test script would abort the whole run on a non-zero exit before any assertion fires.
- Asserts: the symlink still exists; the ownership warning appears in output; the other two skills (absent from the fixture) print `'not installed'`.

---

## Case 9 — bare invocation uses `$PWD`

**The behavior being pinned:**
Calling the script with no arguments triggers `case "") BASE="$PWD"`. The branch was previously untested because the outer `$PWD` in the test script is the **repo root** (set by `cd "$(dirname ...)/.." ` at line 7). Running `"$UNINSTALL"` with no arguments from there would operate on the repo's own `.bob/skills/`.

**How the case is constructed:**
- Installs into `$TMP/bare` using `"$INSTALL" "$TMP/bare"` (same pattern as Case 1 — guarantees correct `SKILL.md` front matter).
- Runs the uninstaller inside an isolated subshell:
  ```bash
  ( cd "$TMP/bare" && "$UNINSTALL" ) >"$TMP/out9" 2>&1
  ```
  The outer `$PWD` is never changed; the subshell's `$PWD` is the temp directory.
- Asserts: all three skills absent after the run; each removal reported in output.

---

## Minor assertion gaps in existing cases (Cases 4, 6, 7)

Three omissions from the original final review, each a one-line addition:

| Case | Gap | Fix |
|---|---|---|
| 4 | No assertion on the warning line | `assert_grep … "SKILL.md declares '<none>'"` — the exact string the ownership branch emits when `DECLARED` is empty. **Not** `"not installed"`: that string is only printed by the `[[ ! -e && ! -L ]]` branch, which is never reached when a directory exists. |
| 6 | `out6` captured but never read | `assert_grep … "Removed 'setup-agentic-scaffolding' from:"` — confirms removal output is non-empty. The `assert_exists "$H/.bob/skills"` assertion already existed at line 104 since v0.18.0; not re-added. |
| 7 | `out7` captured but never read | `assert_grep … "uninstall-bob-skill.sh"` — confirms `--help` output contains usage text. |

The bad-directory output file in Case 7 was also renamed from `out8` → `out7b` to free the name for Case 8.

---

## Result

- **49 assertions across 9 cases**, all passing.
- `shellcheck scripts/*.sh ci/*.sh` clean.
- All other CI gates unaffected: version-consistency, conventions-parity, mcp-command-consistency, markdownlint all green.