### PR TITLE
chore: cut v0.21.0 — baseline on Quarkus 3.39, Bob scope/repair docs, uninstall test coverage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.20.1
+# Version: 0.21.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
-## Unreleased
+## v0.21.0 — 2026-08-27
+- **Baseline moved to the Quarkus 3.39 line.** `ci/baseline.env` goes to platform `3.39.1`
+  (from `3.38.3`, Renovate PR #35). Nothing required a corrective change: the templates compile
+  green against 3.39.1 in the CI compile job and in a local `ci/build-from-templates.sh 3.39.1`
+  run.
+- **`ci/test-uninstall-bob-skill.sh` now pins the dangling-symlink and bare-invocation
+  branches.** Case 8 pins the conservative choice for a symlink whose target is gone: ownership
+  cannot be verified through a broken link, so the uninstaller leaves it in place and warns.
+  Case 9 pins that a bare invocation (no argument) operates on `$PWD`, exercised from an isolated
+  subshell. Three assertion gaps in cases 4, 6, and 7 are closed — 49 assertions across 9 cases,
+  `scripts/uninstall-bob-skill.sh` itself untouched. (#16, PR #41)
 - **The idempotent re-run's repair path now covers `context7`, not just `quarkus-agent`.** The
   v0.18.0 stored-command verification rule stated the repair only for `quarkus-agent` — yet
   `context7` is the more frequent stale entry, since Renovate bumps its pin and every
@@ -11,14 +21,15 @@ versioning.
   `already exists`. The setup skill's §5 verification paragraph now names both pinned strings and
   both `claude mcp remove` forms, §5.1 and the README's *How to use with Bob* carry one
   `bob mcp add-json` example per server, and the Renovate custom managers already track the new
-  occurrences. (#20)
+  occurrences. (#20, PR #39 by @matheusandre1)
 - **Bob's `-s global` MCP registration is now a stated choice, not a silent default.** The setup
   skill's §5 Bob row and §5.1, and the README's *How to use with Bob*, register with `-s global` —
   which writes `~/.bob/settings/mcp.json` and applies to every workspace on the machine — without
   saying so, while the equivalent decision for the conventions file carries an explicit trade-off
   paragraph. All three spots now state the machine-wide scope and why it is the default (the MCPs
   are tools, not conventions, and re-registering per project is friction), and offer `-s workspace`
-  to users who mix stacks — with the ENOENT seeding caveat §5.1 already documents. (#19)
+  to users who mix stacks — with the ENOENT seeding caveat §5.1 already documents. (#19, PR #38
+  by @matheusandre1)
 - **Pasting a whole Bob fence now runs nothing — all three forms are commented.** The v0.20.1
   "Pick one" comment left the first form active, so uncommenting `--global` and pasting the block
   still ran the `<cwd>` form as well. Both fences (install and uninstall, keeping the symmetry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.20.1
+# Version: 0.21.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.20.1
+# Version: 0.21.0
 
 ## What this repository is
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.20.1
+# Version: 0.21.0
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.20.1
+# Version: 0.21.0
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.20.1
+# Version: 0.21.0
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.20.1
+# Version: 0.21.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.20.1
+# Version: 0.21.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Release cut for v0.21.0, covering the four PRs merged since v0.20.1.

## What this changes

- **CHANGELOG.md**: `## Unreleased` → `## v0.21.0 — 2026-08-27`, with two added entries that had no record yet: the `ci/baseline.env` move to platform **3.39.1** (#35 — templates compile green in CI and in a local `ci/build-from-templates.sh 3.39.1` run) and the uninstall-script test coverage from #41 (issue #16). The existing #19/#20 entries now credit PRs #38/#39 by @matheusandre1, matching the v0.20.1 attribution style.
- **Version bump 0.20.1 → 0.21.0** in the nine checked files (README, CLAUDE.md, AGENTS.md, three SKILL.md, three plugin manifests) plus the two conventions seeds.

Minor bump per precedent: v0.14.0 was minor for the 3.38 baseline line move; this release moves the line to 3.39 and changes setup-skill behavior guidance (#19/#20).

## Verified locally

`check-version-consistency` (9 files at 0.21.0), `extract-changelog.sh v0.21.0` (release notes resolve), `check-conventions-parity`, `check-mcp-command-consistency`, `markdownlint-cli2` — all green.

After merge: `git tag -a v0.21.0 -m v0.21.0 && git push origin v0.21.0` publishes the GitHub release via the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)