### PR TITLE
docs: update README to include Gemini CLI installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,13 @@ versioning.
 
 ## Unreleased
 
-- **The README now documents the Gemini CLI install path — and settles #14's open question: the
-  extension stays a gallery listing, not a first-class install path.** `v0.17.0` documented
-  uninstalling an extension no section had ever taught a reader to install. A short
-  *How to use with Gemini* section after *How to use with Bob* closes the loop: the Quick
-  install covers Gemini CLI as a first-class agent (the skills CLI installs into
-  `.agents/skills/`, or `~/.gemini/skills/` globally) and `/setup-agentic-scaffolding` handles
-  the prerequisites, with the extension offered as an optional one-step extra that delivers all
-  three pieces — the three skills (served from the repo's `skills/` directory), both pinned MCP
-  servers, and the conventions via `contextFileName: AGENTS.md` — keeping `v0.10.0`'s framing of
-  the manifest as a gallery listing. The Uninstall section's *"if you installed the extension"*
-  hedge becomes a cross-link to the new section, and the `AGENTS.md` readership lines name
-  Gemini alongside Codex and Bob. Install command verified against Gemini CLI 0.58.0
-  (`gemini extensions install <source>`, a git URL or local path); the extension's skill
-  delivery and the `.agents/skills/`-overrides-extension conflict observed on 0.35.0. (#14)
+- Document Gemini CLI installation as a short note after the Bob instructions: Quick install
+  is the recommended route, and the gallery extension is optional, delivering all three skills,
+  both MCP servers, and conventions. The skills-only route explicitly configures `context.fileName`
+  so Gemini loads `AGENTS.md` alongside its default `GEMINI.md`; users verify with `/memory show`.
+  Cross-link uninstall guidance and include Gemini in the conventions readership. Install syntax
+  was checked against local Gemini CLI `0.35.0` and the contributor's `0.58.0` help output;
+  context configuration was confirmed against the CLI source and official docs via Context7. (#14)
 
 - Update the pinned Context7 MCP package from `4.0.3` to `4.0.6` across setup instructions,
   README commands, and the Gemini extension manifest. (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## Unreleased
+- **The README now documents the Gemini CLI install path — and settles #14's open question: the
+  extension stays a gallery listing, not a first-class install path.** `v0.17.0` documented
+  uninstalling an extension no section had ever taught a reader to install. A short
+  *How to use with Gemini* section after *How to use with Bob* closes the loop: the Quick
+  install covers Gemini CLI as a first-class agent (the skills CLI installs into
+  `.agents/skills/`, or `~/.gemini/skills/` globally) and `/setup-agentic-scaffolding` handles
+  the prerequisites, with the extension offered as an optional one-step extra that delivers all
+  three pieces — the three skills (served from the repo's `skills/` directory), both pinned MCP
+  servers, and the conventions via `contextFileName: AGENTS.md` — keeping `v0.10.0`'s framing of
+  the manifest as a gallery listing. The Uninstall section's *"if you installed the extension"*
+  hedge becomes a cross-link to the new section, and the `AGENTS.md` readership lines name
+  Gemini alongside Codex and Bob. Install command verified against Gemini CLI 0.58.0
+  (`gemini extensions install <source>`, a git URL or local path); the extension's skill
+  delivery and the `.agents/skills/`-overrides-extension conflict observed on 0.35.0. (#14)
+
 ## v0.21.0 — 2026-08-27
 - **Baseline moved to the Quarkus 3.39 line.** `ci/baseline.env` goes to platform `3.39.1`
   (from `3.38.3`, Renovate PR #35). Nothing required a corrective change: the templates compile

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A small, opinionated, distribution-ready artifact for building AI and agent applications on the
 Java stack of **Quarkus + LangChain4j**. It pairs drop-in always-on coding conventions
-(`CLAUDE.md` for Claude, `AGENTS.md` for Codex and Bob) with three skills that set up the
+(`CLAUDE.md` for Claude, `AGENTS.md` for Codex, Bob, and Gemini) with three skills that set up the
 prerequisites, scaffold new projects and components, and audit existing projects — all from
 working templates. The conventions and templates reflect real-world Quarkus + LangChain4j
 practice and a baseline of modern Java, so the guidance captures how these systems are actually
@@ -16,7 +16,8 @@ built rather than generic boilerplate.
 [![Skills](https://www.skills.sh/b/eldermoraes/quarkus-agentic-scaffolding)](https://www.skills.sh/eldermoraes/quarkus-agentic-scaffolding)
 
 The fastest install on any agent that supports the [Agent Skills](https://agentskills.io) format —
-Claude Code, Codex, GitHub Copilot, Cursor, Windsurf, opencode, Amp, IBM Bob, and dozens more:
+Claude Code, Codex, Gemini CLI, GitHub Copilot, Cursor, Windsurf, opencode, Amp, IBM Bob, and
+dozens more:
 
 ```
 npx skills add eldermoraes/quarkus-agentic-scaffolding
@@ -229,9 +230,36 @@ skills are only available in Bob's **Advanced** mode.
 `scaffold-project` produces the layout and starter files and `AGENTS.md` governs the conventions.
 Run `/audit-project` to review an existing project.
 
+## How to use with Gemini
+
+Gemini CLI needs no path of its own. The [Quick install](#quick-install--any-skills-capable-agent)
+(`npx skills add eldermoraes/quarkus-agentic-scaffolding`) covers it as a first-class agent — the
+skills CLI installs all three skills into `.agents/skills/` (project) or `~/.gemini/skills/`
+(global, with `-g`); verify with `gemini skills list`. Then run `/setup-agentic-scaffolding` for
+the prerequisites, as in the three sections above: it verifies the toolchain, registers the
+**Quarkus Agents MCP** and **context7** MCP servers, and drops `AGENTS.md` into your project root.
+
+As an optional extra, the repository is also packaged as a Gemini CLI extension — that is what
+[`gemini-extension.json`](gemini-extension.json) is for, a gallery listing rather than the
+recommended install path. Installing it delivers all three pieces in one step: the three skills
+(served from the repo's `skills/` directory), both MCP servers with the same version pins, and
+the conventions via `contextFileName: AGENTS.md`:
+
+```
+gemini extensions install https://github.com/eldermoraes/quarkus-agentic-scaffolding
+```
+
+(`gemini extensions install <source>` accepts a git URL or a local path — there is no `--source`
+flag; verified against Gemini CLI 0.58.0.) Pick one route, not both: with the skills installed
+both ways, Gemini reports a skill conflict and the `.agents/skills/` copies override the
+extension's. For the `gemini mcp add` scope default, the rule that a `settings.json` registration
+shadows an extension-declared server of the same name, and removal, see [Uninstall](#uninstall).
+Either way, restart the session — extensions and MCP servers load at session start — and try a
+trigger phrase such as *"scaffold a new Quarkus + LangChain4j project"*.
+
 ## What's in `CLAUDE.md` / `AGENTS.md` and why
 
-`CLAUDE.md` (Claude) and `AGENTS.md` (Codex and Bob) are intentionally short and always-on. They
+`CLAUDE.md` (Claude) and `AGENTS.md` (Codex, Bob, and Gemini) are intentionally short and always-on. They
 carry the same project conventions, expressed for the instruction surface each agent reads. Each
 section earns its place:
 
@@ -288,7 +316,7 @@ The split between skill and conventions is deliberate and non-overlapping:
   lay things out, and get them running*, and point at the Quarkus Agents MCP to actually create
   and run the project.
 - **`CLAUDE.md` / `AGENTS.md` are declarative** — they state the conventions the resulting code
-  must follow (`CLAUDE.md` for Claude, `AGENTS.md` for Codex and Bob).
+  must follow (`CLAUDE.md` for Claude, `AGENTS.md` for Codex, Bob, and Gemini).
 
 For Codex distribution, `.agents/plugins/marketplace.json` points to `plugins/quarkus-agentic-scaffolding/`.
 That directory is only a lightweight wrapper with symlinks back to `.codex-plugin/` and `skills/`,
@@ -428,8 +456,9 @@ skill is unlinked, not recursed into. Your MCP registration (`.bob/mcp.json` in 
 left alone. Re-running it is a clean no-op. Skills load once per conversation, so
 **start a new conversation** in Bob afterwards.
 
-**Gemini CLI** — if you installed the extension, uninstalling it takes the two MCP servers it
-declares with it, so add them back at user scope:
+**Gemini CLI** — uninstalling the extension (installed in
+[How to use with Gemini](#how-to-use-with-gemini)) takes the two MCP servers it declares with it,
+so add them back at user scope:
 
 ```
 gemini extensions uninstall quarkus-agentic-scaffolding

--- a/README.md
+++ b/README.md
@@ -230,32 +230,20 @@ skills are only available in Bob's **Advanced** mode.
 `scaffold-project` produces the layout and starter files and `AGENTS.md` governs the conventions.
 Run `/audit-project` to review an existing project.
 
-## How to use with Gemini
+<a id="how-to-use-with-gemini"></a>
 
-Gemini CLI needs no path of its own. The [Quick install](#quick-install--any-skills-capable-agent)
-(`npx skills add eldermoraes/quarkus-agentic-scaffolding`) covers it as a first-class agent — the
-skills CLI installs all three skills into `.agents/skills/` (project) or `~/.gemini/skills/`
-(global, with `-g`); verify with `gemini skills list`. Then run `/setup-agentic-scaffolding` for
-the prerequisites, as in the three sections above: it verifies the toolchain, registers the
-**Quarkus Agents MCP** and **context7** MCP servers, and drops `AGENTS.md` into your project root.
-
-As an optional extra, the repository is also packaged as a Gemini CLI extension — that is what
-[`gemini-extension.json`](gemini-extension.json) is for, a gallery listing rather than the
-recommended install path. Installing it delivers all three pieces in one step: the three skills
-(served from the repo's `skills/` directory), both MCP servers with the same version pins, and
-the conventions via `contextFileName: AGENTS.md`:
-
-```
-gemini extensions install https://github.com/eldermoraes/quarkus-agentic-scaffolding
-```
-
-(`gemini extensions install <source>` accepts a git URL or a local path — there is no `--source`
-flag; verified against Gemini CLI 0.58.0.) Pick one route, not both: with the skills installed
-both ways, Gemini reports a skill conflict and the `.agents/skills/` copies override the
-extension's. For the `gemini mcp add` scope default, the rule that a `settings.json` registration
-shadows an extension-declared server of the same name, and removal, see [Uninstall](#uninstall).
-Either way, restart the session — extensions and MCP servers load at session start — and try a
-trigger phrase such as *"scaffold a new Quarkus + LangChain4j project"*.
+**Gemini CLI.** Use the [Quick install](#quick-install--any-skills-capable-agent): skills go into
+`.agents/skills/` (project) or `~/.gemini/skills/` (global, with `-g`); verify with
+`gemini skills list`, then run `/setup-agentic-scaffolding`. For this route, add `AGENTS.md` to
+[`context.fileName`](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/gemini-md.md)
+in the project's `.gemini/settings.json` (for example, `"context": {"fileName": ["GEMINI.md", "AGENTS.md"]}`),
+preserving existing settings and context filenames: Gemini defaults to `GEMINI.md`, so copying
+`AGENTS.md` alone does not activate the conventions. Alternatively, the optional gallery
+extension installs with `gemini extensions install https://github.com/eldermoraes/quarkus-agentic-scaffolding`
+(the source may also be a local path). It delivers all three skills, both pinned MCP servers, and
+conventions through `contextFileName: AGENTS.md`; use one route to avoid duplicate skills.
+Restart the session and verify the conventions with `/memory show`, then try *"scaffold a new
+Quarkus + LangChain4j project"*. See [Uninstall](#uninstall) for removal and MCP scope/precedence.
 
 ## What's in `CLAUDE.md` / `AGENTS.md` and why
 
@@ -457,7 +445,7 @@ left alone. Re-running it is a clean no-op. Skills load once per conversation, s
 **start a new conversation** in Bob afterwards.
 
 **Gemini CLI** — uninstalling the extension (installed in
-[How to use with Gemini](#how-to-use-with-gemini)) takes the two MCP servers it declares with it,
+[the Gemini CLI note](#how-to-use-with-gemini)) takes the two MCP servers it declares with it,
 so add them back at user scope:
 
 ```


### PR DESCRIPTION
Closes #14.

Document Gemini CLI installation in a short note after the Bob instructions. Quick install plus `/setup-agentic-scaffolding` is the recommended path; the gallery extension remains optional and delivers the three skills, both pinned MCP servers, and conventions.

The skills-only path now explicitly configures `context.fileName` in the project settings to load `AGENTS.md` alongside `GEMINI.md`, preserving existing settings and filenames, and verifies active conventions with `/memory show`. The note links to the existing uninstall and scope/precedence guidance. Issue #49 remains a separate, nonblocking scope-alignment task.

Validation:
- Contributor checked `gemini extensions install --help` on Gemini CLI 0.58.0: the source is a positional Git URL or local path.
- Maintainer reproduced the install help on local Gemini CLI 0.35.0 and inspected its context filename configuration. The existing review also recorded extension skill delivery and precedence on 0.35.0.
- Confirmed custom context filenames and `/memory show` through Context7 against the [official Gemini context documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/gemini-md.md).
- Local Markdown validation passed; GitHub quality checks cover the final commit.

Incorporates current main after PRs #47, #46, #42, and #44, preserving their dependency updates and changelog entries.
