### PR TITLE
docs: scope maintainer tooling requirements by operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,4 +201,10 @@ or override is allowed when justified - for example, pinning a fixed older Java 
 platform threads for a pinning dependency, or selecting a different model provider - and must be
 documented inline near the override so the deviation and its reason stay visible.
 
+When maintaining `eldermoraes/quarkus-agentic-scaffolding` itself, apply the tooling requirements
+per operation as described in `CONTRIBUTING.md` (Required tooling). An unavailable MCP blocks
+only work that needs that tool; independent repository review, documentation, CI inspection,
+and approved merges may continue. This override applies only to maintenance of the scaffolding
+repository; applications using its conventions retain the requirements in section 1.
+
 <!-- END quarkus-agentic-scaffolding conventions -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ versioning.
 
 ## Unreleased
 
+- Scope maintainer tooling requirements to the operation being performed. Missing MCP tools
+  block only dependent work; independent repository reviews, documentation, CI inspection, and
+  approved merges can proceed. Applications using the scaffolding retain their mandatory tools.
+  Record the override in both conventions files, their seed copies, and CONTRIBUTING.md.
 - Document Gemini CLI installation as a short note after the Bob instructions: Quick install
   is the recommended route, and the gallery extension is optional, delivering all three skills,
   both MCP servers, and conventions. The skills-only route explicitly configures `context.fileName`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,4 +201,10 @@ or override is allowed when justified — for example, pinning a fixed older Jav
 platform threads for a pinning dependency, or selecting a different model provider — and must be
 documented inline near the override so the deviation and its reason stay visible.
 
+When maintaining `eldermoraes/quarkus-agentic-scaffolding` itself, apply the tooling requirements
+per operation as described in `CONTRIBUTING.md` (Required tooling). An unavailable MCP blocks
+only work that needs that tool; independent repository review, documentation, CI inspection,
+and approved merges may continue. This override applies only to maintenance of the scaffolding
+repository; applications using its conventions retain the requirements in section 1.
+
 <!-- END quarkus-agentic-scaffolding conventions -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,23 @@ always-on files instead.
 
 ## Required tooling
 
-The same tooling the stack mandates applies to contributors (see `CLAUDE.md` §1 or `AGENTS.md` §1):
+The mandatory tooling in `CLAUDE.md` §1 and `AGENTS.md` §1 governs using the scaffolding in
+Quarkus + LangChain4j applications. When maintaining this repository itself, apply the
+requirements to the operation being performed:
 
-- **Quarkus Agents MCP** for any Quarkus work (project creation, extensions, version checks, docs).
-- **context7** for any external library/framework API lookup (LangChain4j included).
+- **Quarkus Agents MCP** is required for Quarkus project creation, extension selection,
+  configuration, version verification, API lookup, and troubleshooting.
+- **context7** is required for external library/framework API documentation lookup
+  (LangChain4j included).
+- Repository maintenance — inspecting diffs, editing prose, reviewing PRs, checking CI results,
+  and merging approved changes — may proceed without an MCP that the operation does not use.
+  A dependency bump still requires the relevant tool if its review needs an API or Quarkus
+  version lookup.
 
-Do not change a convention or template from model memory or a generic web search — confirm it
-against these tools first.
+If a required tool is unavailable, report and pause only the operation that needs it; continue
+independent maintenance work. Confirm convention or template changes against the relevant tool
+before encoding library/framework behavior. This maintenance scope does not relax the tooling
+requirements for applications using the scaffolding.
 
 ## Proposing a change
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -201,4 +201,10 @@ or override is allowed when justified - for example, pinning a fixed older Java 
 platform threads for a pinning dependency, or selecting a different model provider - and must be
 documented inline near the override so the deviation and its reason stay visible.
 
+When maintaining `eldermoraes/quarkus-agentic-scaffolding` itself, apply the tooling requirements
+per operation as described in `CONTRIBUTING.md` (Required tooling). An unavailable MCP blocks
+only work that needs that tool; independent repository review, documentation, CI inspection,
+and approved merges may continue. This override applies only to maintenance of the scaffolding
+repository; applications using its conventions retain the requirements in section 1.
+
 <!-- END quarkus-agentic-scaffolding conventions -->

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -201,4 +201,10 @@ or override is allowed when justified — for example, pinning a fixed older Jav
 platform threads for a pinning dependency, or selecting a different model provider — and must be
 documented inline near the override so the deviation and its reason stay visible.
 
+When maintaining `eldermoraes/quarkus-agentic-scaffolding` itself, apply the tooling requirements
+per operation as described in `CONTRIBUTING.md` (Required tooling). An unavailable MCP blocks
+only work that needs that tool; independent repository review, documentation, CI inspection,
+and approved merges may continue. This override applies only to maintenance of the scaffolding
+repository; applications using its conventions retain the requirements in section 1.
+
 <!-- END quarkus-agentic-scaffolding conventions -->


### PR DESCRIPTION
Repository-only review and merge work was being blocked whenever an MCP was unavailable, even when that operation did not use the tool. Scope maintainer requirements by operation: continue independent Git, documentation, review, and CI work, and pause only operations needing an unavailable tool.

Quarkus development/version/configuration work and external library API documentation retain their tool requirements. The override explicitly applies only to maintaining this scaffolding repository; consumer applications retain section 1 unchanged. Keep both conventions files and their seed copies synchronized, and record the policy in CONTRIBUTING.md and the Unreleased changelog.

Validation: independent standards/spec review; local conventions/seed parity, version consistency, MCP command consistency, and Markdown validation. GitHub checks must pass before merge.
