### PR TITLE
chore: release v0.21.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.0
+# Version: 0.21.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
-## Unreleased
+## v0.21.1 — 2026-09-09
 
 - Scope maintainer tooling requirements to the operation being performed. Missing MCP tools
   block only dependent work; independent repository reviews, documentation, CI inspection, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.0
+# Version: 0.21.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.0
+# Version: 0.21.1
 
 ## What this repository is
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.0
+# Version: 0.21.1
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.0
+# Version: 0.21.1
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.0
+# Version: 0.21.1
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.0
+# Version: 0.21.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.0
+# Version: 0.21.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Publish the six previously merged maintenance and dependency changes as v0.21.1. Update all nine versioned files and both convention seeds, and promote the existing Unreleased changelog without changing its contents. Plan review and independent standards/spec code reviews passed. Local version consistency, convention parity, changelog extraction, Markdown validation, and MCP command consistency passed. After green CI and merge, tag the merge commit and verify the release workflow publication.