### PR TITLE
ci: verify the MCP Java 21 floor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,25 @@ jobs:
       - uses: actions/checkout@v7
       - run: ci/test-uninstall-bob-skill.sh
       - run: ci/test-conventions-block-removal.sh
+      - run: python3 -m unittest discover -s ci -p 'test_*.py'
+
+  mcp-java-floor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install pinned JBang
+        run: |
+          curl -fsSL --retry 3 https://github.com/jbangdev/jbang/releases/download/v0.138.0/jbang-0.138.0.tar -o "$RUNNER_TEMP/jbang.tar"
+          echo "2b83d1322215b597a1a3e9918d8052737f579d70b9f342521be52c9e3013fd0e  $RUNNER_TEMP/jbang.tar" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/jbang"
+          tar -xf "$RUNNER_TEMP/jbang.tar" -C "$RUNNER_TEMP/jbang" --strip-components=1
+          echo "$RUNNER_TEMP/jbang/bin" >> "$GITHUB_PATH"
+      - run: python3 ci/check_mcp_java_floor.py
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .tmp-audit/
 target/
+__pycache__/
 # Session bookkeeping from agent-driven development - never committed
 .superpowers/
 docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.1
+# Version: 0.21.2
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.21.2 — 2026-09-09
+
+- Check the pinned Quarkus Agents MCP runner on Java 21 in CI using a bounded MCP
+  initialization handshake. Offline tests reject invalid responses and startup failures and
+  verify timeout cleanup, so Renovate updates cannot silently raise the advertised Java floor. (#23)
+
 ## v0.21.1 — 2026-09-09
 
 - Scope maintainer tooling requirements to the operation being performed. Missing MCP tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.1
+# Version: 0.21.2
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,13 @@ The launch command for the Quarkus Agents MCP is hand-maintained in ~15 places, 
 `--java 21+` and the same pinned GAV version. `CHANGELOG.md` and `docs/` are exempt, because they
 quote older commands as a record.
 
+The `mcp-java-floor` quality job also starts the manifest's pinned runner with an exact
+`jbang --java 21` request and requires a valid MCP initialization response. It clears Java/JBang
+runtime overrides and bounds startup time. This checks startup compatibility on the advertised
+minimum JDK, not every tool's runtime behavior. Run `python3 ci/check_mcp_java_floor.py` locally
+with JBang installed; its offline failure-path tests run with
+`python3 -m unittest discover -s ci -p 'test_*.py'`.
+
 ## License
 
 By contributing, you agree your contributions are licensed under the project's

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.1
+# Version: 0.21.2
 
 ## What this repository is
 

--- a/ci/check_mcp_java_floor.py
+++ b/ci/check_mcp_java_floor.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Prove the published MCP runner can initialize with an exact Java 21 request."""
+
+import json
+import os
+from pathlib import Path
+import re
+import selectors
+import signal
+import subprocess
+import tempfile
+import time
+
+
+def runner_coordinate(manifest):
+    args = json.loads(Path(manifest).read_text())["mcpServers"]["quarkus-agent"]["args"]
+    matches = [arg for arg in args if re.fullmatch(
+        r"io\.quarkus:quarkus-agent-mcp:\d+\.\d+\.\d+(?:[-.][\w.-]+)?:runner", arg
+    )]
+    if len(matches) != 1:
+        raise ValueError("Expected one pinned Quarkus Agents MCP runner coordinate")
+    return matches[0]
+
+
+def probe(command, timeout=180, env=None):
+    request = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+        "protocolVersion": "2024-11-05", "capabilities": {},
+        "clientInfo": {"name": "java-floor-check", "version": "1"},
+    }}
+    with tempfile.TemporaryFile() as errors:
+        process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                   stderr=errors, start_new_session=True, env=env)
+        try:
+            process.stdin.write((json.dumps(request) + "\n").encode())
+            process.stdin.flush()
+            deadline = time.monotonic() + timeout
+            pending = b""
+            with selectors.DefaultSelector() as selector:
+                selector.register(process.stdout, selectors.EVENT_READ)
+                while time.monotonic() < deadline:
+                    if not selector.select(min(0.2, max(0, deadline - time.monotonic()))):
+                        continue
+                    chunk = os.read(process.stdout.fileno(), 65536)
+                    if not chunk:
+                        raise RuntimeError("MCP exited before initialize completed")
+                    pending += chunk
+                    if len(pending) > 1024 * 1024:
+                        raise RuntimeError("MCP stdout exceeded the response size limit")
+                    while b"\n" in pending:
+                        line, pending = pending.split(b"\n", 1)
+                        try:
+                            response = json.loads(line)
+                        except (ValueError, UnicodeDecodeError):
+                            continue
+                        if (not isinstance(response, dict) or type(response.get("id")) is not int
+                                or response.get("id") != 1):
+                            continue
+                        result = response.get("result")
+                        info = result.get("serverInfo") if isinstance(result, dict) else None
+                        if (response.get("jsonrpc") != "2.0" or "error" in response
+                                or not isinstance(result, dict)
+                                or result.get("protocolVersion") != "2024-11-05"
+                                or not isinstance(result.get("capabilities"), dict)
+                                or not isinstance(info, dict)
+                                or not isinstance(info.get("name"), str) or not info["name"]
+                                or not isinstance(info.get("version"), str) or not info["version"]):
+                            raise RuntimeError("MCP returned an invalid initialize response")
+                        return info
+            raise RuntimeError(f"MCP initialize timed out after {timeout:g}s")
+        except (RuntimeError, BrokenPipeError) as exc:
+            errors.seek(0, os.SEEK_END)
+            errors.seek(max(0, errors.tell() - 8000))
+            detail = errors.read().decode(errors="replace").strip()
+            raise RuntimeError(f"{exc}\n{detail}".rstrip()) from exc
+        finally:
+            # JBang can spawn Java; stop its whole process group even if the launcher exited.
+            process.poll()  # Reap a dead launcher before signalling its process group on macOS.
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+            process.stdin.close()
+            process.stdout.close()
+
+
+def main():
+    manifest = Path(__file__).resolve().parent.parent / "gemini-extension.json"
+    coordinate = runner_coordinate(manifest)
+    env = {k: v for k, v in os.environ.items() if not k.startswith("JBANG_")
+           and k not in {"JAVA_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS"}}
+    info = probe(["jbang", "--java", "21", coordinate], env=env)
+    print(f"OK: {coordinate} initializes with Java 21 ({info['name']} {info['version']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test_mcp_java_floor.py
+++ b/ci/test_mcp_java_floor.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from check_mcp_java_floor import probe, runner_coordinate
+
+
+class JavaFloorTest(unittest.TestCase):
+    def command(self, response, wait=False):
+        program = "import sys,time; sys.stdin.readline(); "
+        program += f"print({json.dumps(json.dumps(response))}, flush=True); "
+        if wait:
+            program += "time.sleep(30)"
+        return [sys.executable, "-u", "-c", program]
+
+    def test_valid_initialize(self):
+        info = {"name": "quarkus-agent", "version": "fixture"}
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}, "serverInfo": info}
+        self.assertEqual(probe(self.command({"jsonrpc": "2.0", "id": 1, "result": result}, True), 2), info)
+
+    def test_false_positive_responses_fail(self):
+        for response in ({"jsonrpc": "2.0", "id": 1, "error": {"code": -1}},
+                         {"jsonrpc": "2.0", "id": 1, "result": {}},
+                         {"jsonrpc": "2.0", "id": 99, "result": {}}, ["not a response"]):
+            with self.subTest(response=response), self.assertRaises(RuntimeError):
+                probe(self.command(response), 1)
+
+    def test_early_exit_reports_stderr(self):
+        with self.assertRaisesRegex(RuntimeError, "fixture startup failure"):
+            probe([sys.executable, "-c", "import sys; print('fixture startup failure', file=sys.stderr)"], 1)
+
+    def test_timeout_cleans_up_child_process(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pidfile = Path(directory) / "pid"
+            script = ("import subprocess,sys,time; sys.stdin.readline(); "
+                      "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']); "
+                      f"open({str(pidfile)!r},'w').write(str(child.pid)); time.sleep(30)")
+            with self.assertRaisesRegex(RuntimeError, "timed out"):
+                probe([sys.executable, "-c", script], 0.5)
+            # A killed child may briefly remain a zombie until the OS reaps it.
+            result = subprocess.run(["ps", "-o", "stat=", "-p", pidfile.read_text()],
+                                    capture_output=True, text=True)
+            self.assertTrue(not result.stdout.strip() or result.stdout.strip().startswith("Z"))
+
+    def test_coordinate_validation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            for coordinate, valid in (("io.quarkus:quarkus-agent-mcp:1.2.6:runner", True),
+                                      ("https://example.com/code.java", False)):
+                manifest.write_text(json.dumps({"mcpServers": {"quarkus-agent": {"args": [coordinate]}}}))
+                if valid:
+                    self.assertEqual(runner_coordinate(manifest), coordinate)
+                else:
+                    with self.assertRaises(ValueError):
+                        runner_coordinate(manifest)

--- a/ci/test_mcp_java_floor.py
+++ b/ci/test_mcp_java_floor.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 
 from check_mcp_java_floor import probe, runner_coordinate
@@ -39,11 +40,18 @@ class JavaFloorTest(unittest.TestCase):
                       "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']); "
                       f"open({str(pidfile)!r},'w').write(str(child.pid)); time.sleep(30)")
             with self.assertRaisesRegex(RuntimeError, "timed out"):
-                probe([sys.executable, "-c", script], 0.5)
+                probe([sys.executable, "-c", script], 5)
+            self.assertTrue(pidfile.exists(), "fixture did not become ready within 5 seconds")
             # A killed child may briefly remain a zombie until the OS reaps it.
-            result = subprocess.run(["ps", "-o", "stat=", "-p", pidfile.read_text()],
-                                    capture_output=True, text=True)
-            self.assertTrue(not result.stdout.strip() or result.stdout.strip().startswith("Z"))
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                result = subprocess.run(["ps", "-o", "stat=", "-p", pidfile.read_text()],
+                                        capture_output=True, text=True)
+                if not result.stdout.strip() or result.stdout.strip().startswith("Z"):
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail("MCP child process survived timeout cleanup")
 
     def test_coordinate_validation(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.1
+# Version: 0.21.2
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.1
+# Version: 0.21.2
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.1
+# Version: 0.21.2
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.1
+# Version: 0.21.2
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.1
+# Version: 0.21.2
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Closes #23.

Renovate updates previously passed without proving the pinned MCP still starts on Java 21. Add a dedicated quality job that runs the manifest runner through `jbang --java 21`, with runtime overrides removed, and requires a valid MCP initialization response within a deadline. Pin and checksum JBang itself. Preserve the independent check that all published commands match the manifest.

Plan review favored the issue’s executable handshake over inspecting only one class file. Implementation includes process-group cleanup, bounded stderr diagnostics, and offline tests for startup/protocol/timeout failures. Code review corrected scheduling sensitivity in the cleanup test. Standards and spec reviews found no remaining implementation blockers.

Validation: five offline tests, live initialization of runner 1.2.6 on Java 21, actionlint, shellcheck, Markdown validation, version/seed/command consistency, and changelog extraction. Prepare v0.21.2 for tagging after merge; CI must pass first. This proves startup compatibility, not every tool’s behavior.
