### PR TITLE
docs: clarify Context7 authentication for GUI clients

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.2
+# Version: 0.21.3
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.21.3 — 2026-09-09
+
+- Correct Context7 key-delivery guidance for GUI/IDE clients: shell exports apply only to
+  clients launched from that environment. Document secure delivery, full restart, optional-key
+  operation, and verification limits without placing secrets in commands or configuration. (#21)
+
 ## v0.21.2 — 2026-09-09
 
 - Check the pinned Quarkus Agents MCP runner on Java 21 in CI using a bounded MCP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.2
+# Version: 0.21.3
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.2
+# Version: 0.21.3
 
 ## What this repository is
 
@@ -50,6 +50,22 @@ per-agent sections below) namespaces them by the plugin id — `/quarkus-agentic
 `/quarkus-agentic-scaffolding:scaffold-project`, `/quarkus-agentic-scaffolding:audit-project`. Both refer to the same
 skills; use whichever your install produced.
 
+## Context7 authentication and launch environment
+
+The Context7 API key is optional and raises rate limits. The stdio server reads
+`CONTEXT7_API_KEY` from the environment of the agent that launches it. For a terminal-launched
+agent, export the key in that terminal (preferably obtained from a secret manager) **before**
+starting the agent. A GUI/IDE started from the desktop may not inherit shell-profile exports.
+For those clients, use a supported secure environment/secret mechanism, or launch the client
+from the configured terminal if it supports that route. Fully restart an existing client after
+changing its launch environment.
+
+Keep the key out of registration arguments and plaintext configuration. An `${ENV_VAR}`
+reference is valid only when that client supports expansion; some clients store it literally.
+If no secure delivery route is available, use the optional-key server without authentication
+and expect its lower limits. A successful MCP connection, or a presence check in an unrelated
+terminal/login shell, does not prove the server inherited the key. Never print the key to verify it.
+
 ## How to use with Claude
 
 **Install the skills (plugin).** Add this repository as a plugin marketplace and install it:
@@ -72,9 +88,7 @@ setup skill is what puts them in place.
 *Manual fallback,* if you would rather wire it by hand: register the Quarkus Agents MCP with the
 pinned command
 `claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner`;
-add context7 with `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.6` (for higher rate limits
-`export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
-belongs on the command line); optionally install superpowers with
+add context7 with `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.6` (see [authentication and launch environment](#context7-authentication-and-launch-environment)); optionally install superpowers with
 `/plugin marketplace add obra/superpowers-marketplace` then
 `/plugin install superpowers@superpowers-marketplace`; and copy [`CLAUDE.md`](CLAUDE.md) into your
 project root yourself (Claude only auto-loads it from a project root or `~/.claude/`, so no plugin
@@ -115,9 +129,7 @@ registers the **Quarkus Agents MCP** and **context7** MCP servers for Codex, and
 into your project root. `AGENTS.md` §1 makes those two MCP servers non-negotiable for this stack.
 
 *Manual fallback:* add the Quarkus Agents MCP with `codex mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner`;
-add context7 with `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.6` (for higher rate limits
-`export CONTEXT7_API_KEY=…` in your shell — the server picks it up from the environment, so no key
-belongs on the command line); install/enable the Superpowers plugin if you use it; and copy
+add context7 with `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.6` (see [authentication and launch environment](#context7-authentication-and-launch-environment)); install/enable the Superpowers plugin if you use it; and copy
 [`AGENTS.md`](AGENTS.md) into your project root (Codex reads project instructions from the project
 tree).
 
@@ -208,9 +220,9 @@ none of the usual install locations, so if the server fails with `spawn jbang EN
 absolute path from `command -v jbang` in `command` and keep the args as they are. `--java 21+` is not
 optional: the MCP server is compiled for Java 21, and JBang
 resolves its own JDK — it falls back to its default, currently 17, whenever the process that spawned
-it hands over no `JAVA_HOME`, which is exactly what Bob and other GUI-launched clients do. For higher
-rate limits `export CONTEXT7_API_KEY=…` in your environment rather than writing a literal key into
-the file; the server reads it from there.) If the skills CLI is
+it hands over no `JAVA_HOME`, which is exactly what Bob and other GUI-launched clients do. For Context7's optional key, see
+[authentication and launch environment](#context7-authentication-and-launch-environment); a GUI
+client may not inherit shell exports.) If the skills CLI is
 unavailable, the repository's fallback helper installs all three
 skills into `.bob/skills/` for you:
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.2
+# Version: 0.21.3
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.2
+# Version: 0.21.3
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.2
+# Version: 0.21.3
 
 ## 1. When to use this skill
 
@@ -101,16 +101,16 @@ Rules for Phase A:
 Register two MCP servers through the running agent's own mechanism:
 
 - **quarkus-agent** — command `jbang`, args `--java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner`
-- **context7** — command `npx`, args `-y @upstash/context7-mcp@4.0.6`. An API key raises the rate
-  limits, but **do not put it on the command line**: over stdio the server falls back to the
-  `CONTEXT7_API_KEY` environment variable whenever `--api-key` is absent, and a stdio server
-  inherits the agent's environment. So have the user export the key in their shell profile (ideally
-  from a secret manager) and register the server with **no key argument at all**. If a config file
-  must name it, use the entry's `env` map with a reference such as `${CONTEXT7_API_KEY}` where the
-  agent supports expansion — never the literal value. Do not "helpfully" inline the key: a
-  `--api-key $CONTEXT7_API_KEY` typed at a shell is expanded *before* the agent sees it, so the
-  registration command writes the secret into the config in plaintext. And never echo the key to
-  verify it — check presence with `test -n "$CONTEXT7_API_KEY"`, which prints nothing.
+- **context7** — command `npx`, args `-y @upstash/context7-mcp@4.0.6`. The optional
+  `CONTEXT7_API_KEY` raises rate limits and is read from the launching agent's environment.
+  For terminal-launched agents, export it before starting the agent, preferably from a secret
+  manager. Desktop-launched GUI/IDE clients may not inherit shell-profile exports: use a
+  supported secure environment/secret mechanism or launch from the configured terminal where
+  supported, then fully restart the client. If neither is available, explicitly report that
+  the server can run without the optional key at lower limits. Register with **no key argument**
+  and no literal secret in configuration. Use an `env` reference only after verifying that the
+  client expands it; otherwise it may be stored literally. Never print the key. A connection or
+  a key-presence check in a separate terminal/login shell does not prove MCP authentication.
 
 **Registration writes configuration — this skill never runs `jbang` or `npx` itself.** It writes
 the pinned command into the agent's MCP configuration; the agent runtime is what resolves that

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.2
+# Version: 0.21.3
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.2
+# Version: 0.21.3
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Closes #21. Scope shell exports to terminal-launched clients, explain GUI/IDE inheritance and full restart, preserve secure key delivery and optional unauthenticated operation, and remove misleading verification guidance. Three README recipes link to one shared note; setup instructions match. Plan review and independent standards/spec code reviews passed without findings. Markdown, command/version/seed consistency checks passed locally. Prepare v0.21.3 for tag/release after green CI and merge.