### PR TITLE
docs: align Gemini MCP registration scope

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.3
+# Version: 0.21.4
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.21.4 — 2026-09-09
+
+- Align Gemini MCP registration examples on explicit project scope, with user scope as the
+  machine-wide alternative. Check both named-server examples in the README and setup skill
+  so missing scope, mismatched scope, or missing recipes fail CI. (#49)
+
 ## v0.21.3 — 2026-09-09
 
 - Correct Context7 key-delivery guidance for GUI/IDE clients: shell exports apply only to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.3
+# Version: 0.21.4
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.3
+# Version: 0.21.4
 
 ## What this repository is
 
@@ -458,20 +458,20 @@ left alone. Re-running it is a clean no-op. Skills load once per conversation, s
 
 **Gemini CLI** — uninstalling the extension (installed in
 [the Gemini CLI note](#how-to-use-with-gemini)) takes the two MCP servers it declares with it,
-so add them back at user scope:
+so add them back for the current project:
 
 ```
 gemini extensions uninstall quarkus-agentic-scaffolding
-gemini mcp add -s user quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner
-gemini mcp add -s user context7 npx -y @upstash/context7-mcp@4.0.6
+gemini mcp add -s project quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner
+gemini mcp add -s project context7 npx -y @upstash/context7-mcp@4.0.6
 gemini extensions list
 gemini mcp list
 ```
 
 Order matters — uninstall first, then re-add. A `settings.json` registration takes precedence over
 an extension-declared server of the same name, so re-adding *before* uninstalling would silently
-shadow the extension's pinned versions. `gemini mcp add` defaults to `--scope project`, hence
-`-s user`. In `gemini mcp list`, an entry labelled `(from quarkus-agentic-scaffolding)` is still
+shadow the extension's pinned versions. `-s project` makes the CLI's default explicit and keeps registrations in the current project.
+Use `-s user` instead for registrations shared by all projects. In `gemini mcp list`, an entry labelled `(from quarkus-agentic-scaffolding)` is still
 coming from the extension; after a successful uninstall and re-add, both servers appear without
 that label. Restart the session.
 

--- a/ci/check-mcp-command-consistency.sh
+++ b/ci/check-mcp-command-consistency.sh
@@ -36,6 +36,19 @@ for path in FILES:
             unpinned.append((path, flat[max(0, m.start() - 60):m.end()].strip()))
 
 fail = False
+# Check executable Gemini examples, not prose describing the optional user scope.
+gemini = re.compile(r"gemini\s+mcp\s+add(?P<scope>(?:\s+--?[\w-]+\s+\w+)*)"
+                    r"\s+(?P<server>quarkus-agent|context7)\s+(?:jbang|npx)")
+for path in ("README.md", "skills/setup-agentic-scaffolding/SKILL.md"):
+    examples = list(gemini.finditer(open(path, encoding="utf-8").read()))
+    if {match.group("server") for match in examples} != {"quarkus-agent", "context7"}:
+        fail = True
+        print(f"FAIL: {path} must publish both Gemini MCP registration examples", file=sys.stderr)
+    for match in examples:
+        if match.group("scope").split() not in (["-s", "project"], ["--scope", "project"]):
+            fail = True
+            print(f"FAIL: {path} Gemini {match.group('server')} must use explicit project scope",
+                  file=sys.stderr)
 if unpinned:
     fail = True
     print("FAIL: a published registration is missing the `--java 21+` JDK pin.", file=sys.stderr)

--- a/ci/test_mcp_scope.py
+++ b/ci/test_mcp_scope.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class ScopeGuardTest(unittest.TestCase):
+    def run_guard(self, changed_file=None, scope="-s project", missing_server=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "ci").mkdir()
+            (root / "skills/setup-agentic-scaffolding").mkdir(parents=True)
+            guard = root / "ci/check-mcp-command-consistency.sh"
+            guard.write_bytes(Path(__file__).with_name(guard.name).read_bytes())
+            (root / "gemini-extension.json").write_text("{}")
+            for name in ("README.md", "skills/setup-agentic-scaffolding/SKILL.md"):
+                selected = scope if name == changed_file else "-s project"
+                commands = f"gemini mcp add {selected} quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner\n"
+                if not (missing_server and name == changed_file):
+                    commands += f"gemini mcp add {selected} context7 npx -y @upstash/context7-mcp@4.0.6\n"
+                commands += "Use `-s user` instead for all projects.\n"
+                (root / name).write_text(commands)
+            return subprocess.run(["bash", str(guard)], capture_output=True, text=True)
+
+    def test_project_examples_and_user_alternative_pass(self):
+        result = self.run_guard()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_scope_drift_and_missing_examples_fail_on_either_surface(self):
+        for name in ("README.md", "skills/setup-agentic-scaffolding/SKILL.md"):
+            for scope in ("", "-s user"):
+                with self.subTest(name=name, scope=scope):
+                    self.assertNotEqual(self.run_guard(name, scope).returncode, 0)
+            with self.subTest(name=name, missing=True):
+                self.assertNotEqual(self.run_guard(name, missing_server=True).returncode, 0)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.3
+# Version: 0.21.4
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.3
+# Version: 0.21.4
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.3
+# Version: 0.21.4
 
 ## 1. When to use this skill
 
@@ -162,7 +162,7 @@ secrets by design (see the context7 note above), so "exact" is literal: what you
 |---|---|---|---|
 | Claude Code | `claude mcp add -s user quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `claude mcp add -s user context7 -- npx -y @upstash/context7-mcp@4.0.6` | `claude mcp list` | No — restart |
 | Codex CLI | `codex mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `codex mcp add context7 -- npx -y @upstash/context7-mcp@4.0.6` | `codex mcp list` | No — restart; sandbox may block network |
-| Gemini CLI | `gemini mcp add quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `gemini mcp add context7 npx -y @upstash/context7-mcp@4.0.6` (project scope — `gemini mcp add` defaults to `--scope project`; add `-s user` to register them for every project) — **or** install this repo's Gemini extension, which already declares both servers | `gemini mcp list` | No — restart |
+| Gemini CLI | `gemini mcp add -s project quarkus-agent jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `gemini mcp add -s project context7 npx -y @upstash/context7-mcp@4.0.6` (project scope — `gemini mcp add` defaults to `--scope project`; replace `-s project` with `-s user` to register them for every project) — **or** install this repo's Gemini extension, which already declares both servers | `gemini mcp list` | No — restart |
 | Cursor | Write `.cursor/mcp.json` with both servers (`mcpServers` map, same command/args) | Settings → MCP shows both; user **toggles them on** | GUI enable |
 | GitHub Copilot CLI | `copilot mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `copilot mcp add context7 -- npx -y @upstash/context7-mcp@4.0.6` | `copilot mcp list` | **Yes** — live immediately |
 | opencode | Write `opencode.json` `mcp` key with both servers | `/mcp` in session | **Yes** — hot reload |

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.3
+# Version: 0.21.4
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.3
+# Version: 0.21.4
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Closes #49. Standardize both published Gemini recipes on explicit project scope, keeping user scope as the documented machine-wide alternative. Extend the existing command guard to require both named-server examples on both surfaces and reject missing/mismatched scope. Plan review and independent standards/spec reviews passed. CLI help confirms the default; regression fixtures, Markdown, shell/workflow lint, and version/seed consistency passed. Prepare v0.21.4 for release after green CI and merge.