### PR TITLE
fix: align uninstall precheck and complete AWK drift guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.4
+# Version: 0.21.5
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.21.5 — 2026-09-09
+
+### Fixed
+
+- Align the uninstall precheck with the full END marker required by removal, and guard the complete published AWK program against drift (#15).
+
 ## v0.21.4 — 2026-09-09
 
 - Align Gemini MCP registration examples on explicit project scope, with user scope as the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.4
+# Version: 0.21.5
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.4
+# Version: 0.21.5
 
 ## What this repository is
 
@@ -504,7 +504,7 @@ cp CLAUDE.md "CLAUDE.md.backup-$(date +%Y%m%d-%H%M%S)"
 
 # 2. Precheck — proceed ONLY on OK-SAFE-TO-REMOVE
 awk '/^<!-- BEGIN quarkus-agentic-scaffolding conventions/{b++;bl=NR}
-     /^<!-- END quarkus-agentic-scaffolding conventions/{e++;el=NR}
+     /^<!-- END quarkus-agentic-scaffolding conventions -->/{e++;el=NR}
      END{printf "BEGIN=%d END=%d beginLine=%d endLine=%d -> %s\n", b,e,bl,el,
          (b==1 && e==1 && bl<el) ? "OK-SAFE-TO-REMOVE" : "REFUSE - remove the block by hand"}' CLAUDE.md
 ```

--- a/ci/test-conventions-block-removal.sh
+++ b/ci/test-conventions-block-removal.sh
@@ -23,8 +23,9 @@ BEGIN_MARKER='<!-- BEGIN quarkus-agentic-scaffolding conventions (managed block;
 END_MARKER='<!-- END quarkus-agentic-scaffolding conventions -->'
 
 # --- The two published commands, defined once. ---------------------------------
+# BEGIN remains prefix-matched in both commands; END requires the same full literal.
 AWK_PROG='/^<!-- BEGIN quarkus-agentic-scaffolding conventions/{b++;bl=NR}
-     /^<!-- END quarkus-agentic-scaffolding conventions/{e++;el=NR}
+     /^<!-- END quarkus-agentic-scaffolding conventions -->/{e++;el=NR}
      END{printf "BEGIN=%d END=%d beginLine=%d endLine=%d -> %s\n", b,e,bl,el,
          (b==1 && e==1 && bl<el) ? "OK-SAFE-TO-REMOVE" : "REFUSE - remove the block by hand"}'
 PERL_SUB='s/^<!-- BEGIN quarkus-agentic-scaffolding conventions.*?^<!-- END quarkus-agentic-scaffolding conventions -->[ \t]*\r?\n?//msg'
@@ -180,6 +181,11 @@ printf "KEEP\n\nI removed the \`%s\` line by hand.\n\n%s\n\nMORE-OF-MINE\n" \
   "$BEGIN_MARKER" "$END_MARKER" >"$f"
 run_group_b 'B6 prose BEGIN plus a real END' "$f"
 
+# B7: a hand-edited END must not pass when the remover cannot match it.
+f="$TMP/b7.md"
+printf 'KEEP\n%s\nrule one\n<!-- END quarkus-agentic-scaffolding conventions (v0.16) -->\nTAIL\n' "$BEGIN_MARKER" >"$f"
+run_group_b 'B7 hand-edited END' "$f"
+
 # ============================================================================
 # Group C - two complete blocks. The precheck refuses on count, deliberately, so a
 # human eyeballs a duplicated block. The removal is NOT run: perl's /g would happily
@@ -269,14 +275,29 @@ if grep -Fq "perl -i -0777 -pe '$PERL_SUB'" README.md; then
 else
   fail 'README no longer publishes the validated perl command - it drifted from this test'
 fi
-for frag in 'b++;bl=NR' 'e++;el=NR' 'b==1 && e==1 && bl<el' 'OK-SAFE-TO-REMOVE' \
-            "grep -q '[^[:space:]]'"; do
-  if grep -Fq "$frag" README.md; then
-    pass "README still carries the precheck fragment: $frag"
-  else
-    fail "README lost the precheck fragment: $frag"
-  fi
-done
+if python3 - "$AWK_PROG" <<'PYTHON'
+from pathlib import Path
+import re
+import sys
+
+programs = re.findall(r"\bawk '([^']+)' CLAUDE\.md", Path("README.md").read_text())
+# Ignore indentation only, preserving whitespace inside expressions and strings.
+def normalize(program):
+    return "\n".join(line.strip() for line in program.splitlines())
+
+if len(programs) != 1 or normalize(programs[0]) != normalize(sys.argv[1]):
+    sys.exit("README must publish exactly one copy of the validated AWK program")
+PYTHON
+then
+  pass 'README publishes the complete validated AWK program'
+else
+  fail 'README AWK program drifted from this test'
+fi
+if grep -Fq "grep -q '[^[:space:]]'" README.md; then
+  pass 'README carries the whitespace-only file check'
+else
+  fail 'README lost the whitespace-only file check'
+fi
 if grep -Eq "sed -i.*(BEGIN|END) quarkus-agentic-scaffolding" README.md; then
   fail 'README publishes a sed -i procedure for the managed block - see spec Finding 1'
 else
@@ -289,7 +310,7 @@ else
 fi
 
 if [[ "$failures" == 0 ]]; then
-  echo 'OK: managed-block removal behaves as documented on all 15 fixtures, and README matches'
+  echo 'OK: managed-block removal behaves as documented on all 16 fixtures, and README matches'
 else
   echo "FAIL: $failures assertion(s) failed" >&2
   exit 1

--- a/ci/test_uninstall_drift.py
+++ b/ci/test_uninstall_drift.py
@@ -1,0 +1,37 @@
+"""The README guard must catch changes beyond the former AWK fragments."""
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class UninstallDriftTests(unittest.TestCase):
+    def check_readme(self, transform, success):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'ci').mkdir()
+            script = root / 'ci/test-conventions-block-removal.sh'
+            shutil.copyfile(ROOT / 'ci/test-conventions-block-removal.sh', script)
+            (root / 'README.md').write_text(transform((ROOT / 'README.md').read_text()))
+            result = subprocess.run(['bash', str(script)], capture_output=True, text=True)
+            self.assertEqual(result.returncode == 0, success, result.stdout + result.stderr)
+
+    def test_indentation_is_allowed(self):
+        self.check_readme(lambda text: text.replace('     END{printf', '         END{printf'), True)
+
+    def test_semantic_drift_is_rejected(self):
+        for old, new in [('b,e,bl,el,', 'e,b,bl,el,'),
+                         ('REFUSE - remove the block by hand', 'REFUSE - continue anyway')]:
+            with self.subTest(old=old):
+                self.check_readme(lambda text: text.replace(old, new), False)
+
+    def test_missing_or_duplicate_program_is_rejected(self):
+        self.check_readme(lambda text: text.replace("awk '", "gawk '"), False)
+        self.check_readme(lambda text: text + '\n' + text, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.4
+# Version: 0.21.5
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.4
+# Version: 0.21.5
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.4
+# Version: 0.21.5
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.4
+# Version: 0.21.5
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.4
+# Version: 0.21.5
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
The uninstall precheck accepted a hand-edited END marker that the remover ignored. Require the same full END literal in both commands and verify refusal leaves that file unchanged.

Replace fragment checks with a complete AWK program comparison, preserving indentation flexibility. Mutation tests cover changed output fields, refusal text, missing programs and duplicate programs. BEGIN matching and the documented residual behavior remain unchanged.

Closes #15.

Plan review approved; independent Standards and Spec reviews reported zero findings. Checks: both shell behavior suites, 10 Python tests, Markdown lint, ShellCheck, actionlint, version consistency, convention parity and MCP command consistency passed. Prepares v0.21.5 for the authorized release after merge.
