### PR TITLE
feat: automate release version and seed updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.21.5",
+  "version": "0.22.0",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.5",
+  "version": "0.22.0",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 #
 #   git tag -a v0.16.0 -m v0.16.0 && git push origin v0.16.0
 #
-# The job refuses to publish unless the tag, the nine versioned files, and the
+# The job refuses to publish unless the tag, the versioned files, and the
 # changelog all agree — a tag pushed at the wrong commit fails loudly instead of
 # producing a release whose notes describe something else.
 on:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: The nine versioned files agree with each other
+      - name: The versioned files agree with each other
         run: ci/check-version-consistency.sh
 
       - name: ...and with the tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.5
+# Version: 0.22.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.22.0 — 2026-09-09
+
+### Added
+
+- Automate release version updates and convention seed copies with `ci/bump-version.sh`, using a shared inventory for version checks and seed parity (#24).
+
 ## v0.21.5 — 2026-09-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.5
+# Version: 0.22.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,15 +88,14 @@ Conventions and templates should reflect how real Quarkus + LangChain4j systems 
 
 ## Versioning
 
-This artifact uses semantic versioning. Keep the version header identical across `README.md`,
-`CLAUDE.md`, `AGENTS.md`, the three `skills/*/SKILL.md` files, `.claude-plugin/plugin.json`,
-`.codex-plugin/plugin.json`, and `gemini-extension.json` (nine files, enforced by
-`ci/check-version-consistency.sh`), and record every change in `CHANGELOG.md` — contributors add
-theirs under `## Unreleased`, and the maintainer renames that section to the new version and bumps
-all nine headers in the same release commit. A version bump also
-reaches the two seed copies the setup skill ships —
-`skills/setup-agentic-scaffolding/templates/conventions-{CLAUDE,AGENTS}.md` — so re-copy the root
-files over them; `ci/check-conventions-parity.sh` fails on the drift otherwise.
+This artifact uses semantic versioning. The canonical file inventory and seed mappings live in
+`ci/versioning.py`; `ci/check-version-consistency.sh` checks their version agreement. Contributors
+record changes under `## Unreleased` in `CHANGELOG.md`. At release time, the maintainer runs
+`ci/bump-version.sh <major.minor.patch>` and renames the changelog section to that version in the
+same commit. The command preserves file formatting and re-copies the root conventions into the
+setup skill's seeds. It validates inputs before writing; it does not provide rollback for a
+filesystem failure during writes. Review the diff and run the version and convention parity
+checks before tagging.
 
 The launch command for the Quarkus Agents MCP is hand-maintained in ~15 places, and
 `ci/check-mcp-command-consistency.sh` couples them: every published registration must carry

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.21.5
+# Version: 0.22.0
 
 ## What this repository is
 
@@ -638,7 +638,8 @@ instruction files once at startup.
 This artifact uses semantic versioning. `README.md`, `CLAUDE.md`, `AGENTS.md`, the three
 `skills/*/SKILL.md` files (`setup-agentic-scaffolding`, `scaffold-project`, `audit-project`),
 `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `gemini-extension.json` each carry
-a matching version header — nine files, enforced in CI by `ci/check-version-consistency.sh`. See
+a matching version header, enforced in CI by `ci/check-version-consistency.sh` using the inventory
+in `ci/versioning.py`. Maintainers update them with `ci/bump-version.sh <major.minor.patch>`. See
 [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
 ## License

--- a/ci/bump-version.sh
+++ b/ci/bump-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Update the canonical release inventory and re-copy convention seeds.
+set -euo pipefail
+exec python3 "$(dirname "${BASH_SOURCE[0]}")/versioning.py" bump "$@"

--- a/ci/check-conventions-parity.sh
+++ b/ci/check-conventions-parity.sh
@@ -66,6 +66,7 @@ fi
 # --- Seed-copy parity: the setup skill ships byte-for-byte copies of the root -
 # conventions files (it drops them into the user's project in Phase C). These are
 # plain copies, not normalized twins, so a plain diff must match exactly.
+seed_pairs="$(python3 ci/versioning.py seeds)"
 seed_fail=0
 while IFS='|' read -r root seed; do
   if seed_diff="$(diff -u "$root" "$seed")"; then
@@ -79,8 +80,5 @@ while IFS='|' read -r root seed; do
     } >&2
     seed_fail=1
   fi
-done <<'SEEDS'
-CLAUDE.md|skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
-AGENTS.md|skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
-SEEDS
+done <<<"$seed_pairs"
 [[ "$seed_fail" == 0 ]] || exit 1

--- a/ci/check-version-consistency.sh
+++ b/ci/check-version-consistency.sh
@@ -1,23 +1,4 @@
 #!/usr/bin/env bash
-# Fails unless the nine versioned files carry one identical version.
+# Fails unless every file in the canonical inventory carries the same version.
 set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-md_versions="$(grep -hoE '^# Version: [0-9]+\.[0-9]+\.[0-9]+' \
-  README.md CLAUDE.md AGENTS.md \
-  skills/setup-agentic-scaffolding/SKILL.md \
-  skills/scaffold-project/SKILL.md \
-  skills/audit-project/SKILL.md \
-  | awk '{print $3}')"
-json_versions="$(python3 -c '
-import json
-for f in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json", "gemini-extension.json"):
-    print(json.load(open(f))["version"])')"
-all="$(printf '%s\n%s\n' "$md_versions" "$json_versions")"
-count_files="$(printf '%s\n' "$all" | wc -l | tr -d ' ')"
-count_unique="$(printf '%s\n' "$all" | sort -u | wc -l | tr -d ' ')"
-if [[ "$count_files" != "9" || "$count_unique" != "1" ]]; then
-  echo "FAIL: expected 9 identical version headers, got $count_files entries / $count_unique distinct:" >&2
-  printf '%s\n' "$all" >&2
-  exit 1
-fi
-echo "OK: version $(printf '%s\n' "$all" | head -1) consistent across 9 files"
+exec python3 "$(dirname "${BASH_SOURCE[0]}")/versioning.py" check "$@"

--- a/ci/test_versioning.py
+++ b/ci/test_versioning.py
@@ -1,0 +1,96 @@
+"""Release updates preserve content and fail validation before changing files."""
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import versioning
+
+
+class VersioningTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        for name in versioning.MARKDOWN:
+            self.write(name, b'# Title\r\n# Version: 1.2.3\r\nOther 1.2.3 text\r\n')
+        for name in versioning.JSON_FILES:
+            self.write(name, b'{\r\n "nested": {"version":"9.9.9"}, "version" : "1.2.3", "other": true\r\n}\r\n')
+        for seed in versioning.SEEDS.values():
+            self.write(seed, b'stale seed')
+
+    def write(self, name, data):
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def snapshot(self):
+        return {str(path.relative_to(self.root)): path.read_bytes()
+                for path in self.root.rglob('*') if path.is_file()}
+
+    def test_bump_preserves_content_and_copies_seeds(self):
+        before = self.snapshot()
+        versioning.bump(self.root, '2.0.0')
+        after = self.snapshot()
+        for name in versioning.MARKDOWN:
+            self.assertEqual(after[name], before[name].replace(b'# Version: 1.2.3', b'# Version: 2.0.0'))
+        for name in versioning.JSON_FILES:
+            self.assertEqual(after[name], before[name].replace(b'"1.2.3"', b'"2.0.0"'))
+        for source, seed in versioning.SEEDS.items():
+            self.assertEqual(after[seed], after[source])
+
+    def test_invalid_versions_do_not_write(self):
+        for version in ('v2.0.0', '2.0', '01.2.3', '2.0.0-beta', '2.0.0\n'):
+            with self.subTest(version=version):
+                before = self.snapshot()
+                with self.assertRaises(ValueError):
+                    versioning.bump(self.root, version)
+                self.assertEqual(before, self.snapshot())
+
+    def test_bad_sources_do_not_write(self):
+        name = versioning.JSON_FILES[-1]
+        original = (self.root / name).read_bytes()
+        for malformed in (b'{"version":"1.2.3","version":"1.2.3"}',
+                          b'{"nested":{"version":"1.2.3"}}', b'{', b'{"version":12}'):
+            with self.subTest(malformed=malformed):
+                self.write(name, malformed)
+                before = self.snapshot()
+                with self.assertRaises(ValueError):
+                    versioning.bump(self.root, '2.0.0')
+                self.assertEqual(before, self.snapshot())
+        self.write(name, original)
+        for missing in (name, next(iter(versioning.SEEDS.values()))):
+            path = self.root / missing
+            data = path.read_bytes()
+            path.unlink()
+            before = self.snapshot()
+            with self.assertRaises((ValueError, OSError)):
+                versioning.bump(self.root, '2.0.0')
+            self.assertEqual(before, self.snapshot())
+            path.write_bytes(data)
+
+    def test_header_count_and_version_mismatch(self):
+        name = versioning.MARKDOWN[0]
+        for contents in (b'# Version: 1.2.3\n# Version: 1.2.3\n', b'No header', b'# Version: broken'):
+            self.write(name, contents)
+            before = self.snapshot()
+            with self.assertRaises(ValueError):
+                versioning.bump(self.root, '2.0.0')
+            self.assertEqual(before, self.snapshot())
+        self.write(name, b'# Version: 2.0.0\n')
+        with self.assertRaises(ValueError):
+            versioning.check(self.root)
+
+    def test_checker_count_comes_from_inventory(self):
+        self.write('extra.md', b'# Version: 1.2.3\n')
+        with patch.object(versioning, 'MARKDOWN', (*versioning.MARKDOWN, 'extra.md')):
+            output = StringIO()
+            with redirect_stdout(output):
+                versioning.check(self.root)
+            self.assertEqual(output.getvalue(), 'OK: version 1.2.3 consistent across 10 files\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ci/versioning.py
+++ b/ci/versioning.py
@@ -1,0 +1,110 @@
+"""Canonical release inventory and formatting-preserving version updates."""
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+MARKDOWN = (
+    'README.md', 'CLAUDE.md', 'AGENTS.md',
+    'skills/setup-agentic-scaffolding/SKILL.md',
+    'skills/scaffold-project/SKILL.md', 'skills/audit-project/SKILL.md',
+)
+JSON_FILES = ('.claude-plugin/plugin.json', '.codex-plugin/plugin.json', 'gemini-extension.json')
+SEEDS = {f'{name}.md': f'skills/setup-agentic-scaffolding/templates/conventions-{name}.md'
+         for name in ('CLAUDE', 'AGENTS')}
+VERSION = r'(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)'
+
+
+def unique_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f'duplicate JSON key: {key}')
+        result[key] = value
+    return result
+
+
+def version_span(text, name):
+    if name in MARKDOWN:
+        matches = list(re.finditer(r'^# Version: ([^\r\n]*)', text, re.M))
+        if len(matches) != 1:
+            raise ValueError(f'{name}: expected exactly one version header')
+        start, end = matches[0].span(1)
+    else:
+        data = json.loads(text, object_pairs_hook=unique_keys)
+        if not isinstance(data, dict) or not isinstance(data.get('version'), str):
+            raise ValueError(f'{name}: expected a top-level version string')
+        # Walk top-level members so nested version fields remain untouched.
+        decoder = json.JSONDecoder()
+        position = text.index('{') + 1
+        while True:
+            position = re.compile(r'\s*').match(text, position).end()
+            key, position = decoder.raw_decode(text, position)
+            position = re.compile(r'\s*:\s*').match(text, position).end()
+            value_start = position
+            _, position = decoder.raw_decode(text, position)
+            if key == 'version':
+                start, end = value_start + 1, position - 1
+                break
+            position = re.compile(r'\s*,\s*').match(text, position).end()
+    if not re.fullmatch(VERSION, text[start:end]):
+        raise ValueError(f'{name}: invalid version {text[start:end]!r}')
+    return start, end
+
+
+def inventory(root):
+    result = {}
+    for name in (*MARKDOWN, *JSON_FILES):
+        text = (root / name).read_bytes().decode('utf-8')
+        start, end = version_span(text, name)
+        result[name] = (text, start, end)
+    return result
+
+
+def check(root):
+    files = inventory(root)
+    versions = {text[start:end] for text, start, end in files.values()}
+    if len(versions) != 1:
+        raise ValueError(f'version mismatch: {sorted(versions)}')
+    print(f'OK: version {versions.pop()} consistent across {len(files)} files')
+
+
+def bump(root, version):
+    if not re.fullmatch(VERSION, version):
+        raise ValueError('new version must be numeric major.minor.patch without leading zeros')
+    files = inventory(root)
+    updates = {name: (text[:start] + version + text[end:]).encode('utf-8')
+               for name, (text, start, end) in files.items()}
+    for source, seed in SEEDS.items():
+        # Validate destinations before writing; stale seeds are deliberately repaired.
+        if not (root / seed).is_file():
+            raise ValueError(f'missing seed file: {seed}')
+        updates[seed] = updates[source]
+    for name, content in updates.items():
+        (root / name).write_bytes(content)
+    print(f'Updated {len(updates)} files to {version}; update CHANGELOG.md before releasing')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=('check', 'bump', 'seeds'))
+    parser.add_argument('version', nargs='?')
+    args = parser.parse_args()
+    if (args.command == 'bump') != (args.version is not None):
+        parser.error('only bump requires a version argument')
+    root = Path(__file__).resolve().parent.parent
+    try:
+        if args.command == 'check':
+            check(root)
+        elif args.command == 'bump':
+            bump(root, args.version)
+        else:
+            for source, seed in SEEDS.items():
+                print(f'{source}|{seed}')
+    except (OSError, ValueError) as error:
+        sys.exit(f'FAIL: {error}')
+
+
+if __name__ == '__main__':
+    main()

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.21.5",
+  "version": "0.22.0",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.21.5
+# Version: 0.22.0
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.21.5
+# Version: 0.22.0
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.21.5
+# Version: 0.22.0
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.21.5
+# Version: 0.22.0
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.21.5
+# Version: 0.22.0
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Release version updates previously required manual edits across manifests, skill headers and convention seeds. Add `ci/bump-version.sh <major.minor.patch>` to update the shared inventory and re-copy seeds while preserving formatting.

The consistency checker derives its count from that inventory, and seed parity uses the same mapping. Validate all inputs before writing; changelog editing remains the maintainer's responsibility. Document the command and remove hardcoded file counts.

Closes #24.

Plan review approved. Independent Standards and Spec reviews: zero findings. Checks passed: 15 Python tests, version/seed/MCP consistency, Markdown lint, ShellCheck and actionlint. The new command prepared v0.22.0 in this PR.
