### PR TITLE
docs: load Bob setup details on demand

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.22.0
+# Version: 0.22.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.22.1 — 2026-09-09
+
+### Changed
+
+- Load Bob MCP details from a shared on-demand reference, shipped by the fallback installer;
+  keep Java and version-pin imperatives in the setup skill and include references in Renovate
+  and MCP command checks (#22).
+- Setup `SKILL.md` shrank from 28,199 to 21,696 UTF-8 bytes and from 7,246 to 5,545 tokens
+  (v0.22.0 versus v0.22.1, tiktoken 0.14.0, `o200k_base`: 23.5% fewer tokens).
+  This measures the main skill only, not the full package or Bob's additional reference load.
+
 ## v0.22.0 — 2026-09-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.22.0
+# Version: 0.22.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.22.0
+# Version: 0.22.1
 
 ## What this repository is
 
@@ -149,80 +149,16 @@ registers the **Quarkus Agents MCP** and **context7** MCP servers for Bob, and d
 into your project root. If you already added `AGENTS.md` for Codex, the same file serves Bob — there
 is no separate `BOB.md`.
 
-*Manual fallback:* register both servers with Bob's own CLI (Bob 2.0.0), which writes the file Bob
-actually reads:
+*Manual fallback:* before registering either server, read the
+[Bob MCP registration guide](skills/setup-agentic-scaffolding/references/bob-mcp.md).
+It is the shared procedure for configuration paths, legacy migration, scope selection, the required
+`--` separator, updating existing entries, and verification with or without the CLI.
 
-```
-bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner
-bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.6
-bob mcp list
-```
+For GUI launch environments, ensure JBang is resolvable by Bob; if needed use its absolute path
+from `command -v jbang`. Keep `--java 21+` in the arguments. Context7's optional key follows the
+[authentication and launch environment](#context7-authentication-and-launch-environment) guidance.
 
-The `--` is required: without it Bob parses `--java` as one of its own options and exits with
-`error: unknown option '--java'`.
-
-**Trade-off (stated explicitly):** `-s global` writes `~/.bob/settings/mcp.json` and registers both
-servers for **every workspace on the machine**, not just this project. That is the default here
-because these MCP servers are tools, not conventions — they answer Quarkus and library questions
-and change nothing in projects that never call them — and re-registering them per project is
-friction. If you mix stacks and want nothing of this artifact reaching your other work, register at
-workspace scope instead: `-s workspace` is Bob's own default, so dropping the flag means the same
-thing — it registers in the current project only. One caveat at that scope: Bob does not create
-`<project>/.bob/mcp.json`, so the command dies with `ENOENT … .bob/mcp.json` when the file is
-missing. Seed it **only if it is missing** — `>` truncates, and an existing file holds
-registrations worth keeping:
-
-```
-[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }
-```
-
-At global scope Bob creates the file and its directory for you. On a name that is already
-registered, `add` refuses (`Error: MCP server "quarkus-agent" already exists`) — to *replace* a
-stale entry use `bob mcp add-json`, which overwrites in place. One form per server:
-
-```
-bob mcp add-json -s global quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.6:runner"]}'
-bob mcp add-json -s global context7 '{"command":"npx","args":["-y","@upstash/context7-mcp@4.0.6"]}'
-```
-
-Read what `bob mcp list` prints, not just the names: an entry from an older setup shows its own
-command, and a stale command is exactly the case `add-json` is for — on **either** server. For
-`quarkus-agent` that looks like an unpinned `jbang quarkus-agent-mcp@quarkusio`; for `context7` it
-is an older version pin, and that is the *frequent* one — the `@upstash/context7-mcp` pin moves
-with every upstream release (Renovate keeps this guide current), so a machine set up before the
-latest bump holds the previous version until you overwrite it.
-
-To write the JSON by hand instead, the global file is `~/.bob/settings/mcp.json` and the project
-file is `<project>/.bob/mcp.json` (a same-named server at project scope overrides global). Older
-Bob docs name `mcp_settings.json` in that same settings directory; Bob 2.0.0 treats it as legacy and
-migrates it **only when `mcp.json` does not yet exist**, so on a machine that already has `mcp.json`
-anything written to the legacy name is silently ignored. That cuts both ways, so **look before you
-register**: if `~/.bob/settings/mcp_settings.json` exists and `mcp.json` does not, start Bob once and
-let it migrate (it says so — *"your global MCP configuration has been migrated to mcp.json"*) before
-running any `bob mcp add`. Adding first creates `mcp.json` yourself, and the migration then never
-runs — your old servers stay in the legacy file, unread. If you set Bob up with a version of this
-guide before v0.18.0, also look for `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` — one directory
-above `settings/`, which is where we used to point you; Bob reads neither, so a registration sitting
-there has never loaded. Contents either way:
-
-```json
-{
-  "mcpServers": {
-    "quarkus-agent": { "command": "jbang", "args": ["--java", "21+", "io.quarkus:quarkus-agent-mcp:1.2.6:runner"] },
-    "context7":      { "command": "npx",   "args": ["-y", "@upstash/context7-mcp@4.0.6"] }
-  }
-}
-```
-
-(`jbang` must be on the PATH of whatever *starts* Bob — install it with a package manager, e.g.
-`sdk install jbang` or `brew install jbang`. A GUI-launched client gets a minimal PATH that contains
-none of the usual install locations, so if the server fails with `spawn jbang ENOENT`, put the
-absolute path from `command -v jbang` in `command` and keep the args as they are. `--java 21+` is not
-optional: the MCP server is compiled for Java 21, and JBang
-resolves its own JDK — it falls back to its default, currently 17, whenever the process that spawned
-it hands over no `JAVA_HOME`, which is exactly what Bob and other GUI-launched clients do. For Context7's optional key, see
-[authentication and launch environment](#context7-authentication-and-launch-environment); a GUI
-client may not inherit shell exports.) If the skills CLI is
+If the skills CLI is
 unavailable, the repository's fallback helper installs all three
 skills into `.bob/skills/` for you:
 
@@ -336,7 +272,7 @@ copying the file into each project:
   context file. (Bob also loads global *rules* from `~/.bob/rules/`, so
   `~/.bob/rules/quarkus-langchain4j.md` works too if you would rather keep them separate from your
   general context.) Install the skills globally with `./scripts/install-bob-skill.sh --global`
-  (into `~/.bob/skills/`), and add the shared MCP servers with the `bob mcp add -s global` commands
+  (into `~/.bob/skills/`), and add the shared MCP servers with the scope-aware registration procedure
   from [How to use with Bob](#how-to-use-with-bob) — not by hand in the **MCP** tab, which is how a
   registration ends up without the `--java 21+` pin.
 

--- a/ci/check-mcp-command-consistency.sh
+++ b/ci/check-mcp-command-consistency.sh
@@ -18,7 +18,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 python3 - <<'PY'
 import glob, re, sys
 
-FILES = ["README.md", "gemini-extension.json"] + sorted(glob.glob("skills/*/SKILL.md"))
+FILES = ["README.md", "gemini-extension.json"] + sorted(glob.glob("skills/*/SKILL.md") + glob.glob("skills/*/references/*.md"))
 GAV = re.compile(r"io\.quarkus:quarkus-agent-mcp:([0-9][^\s\"'`,\]]*):runner")
 # Flatten the punctuation that separates a JSON args array or a wrapped line, so a
 # markdown command, a JSON "args" list, and a quoted add-json payload all normalize

--- a/ci/test_bob_references.py
+++ b/ci/test_bob_references.py
@@ -1,0 +1,27 @@
+"""Bob's fallback installation includes and refreshes on-demand instructions."""
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class BobReferenceTests(unittest.TestCase):
+    def test_install_and_refresh_reference(self):
+        with tempfile.TemporaryDirectory() as directory:
+            command = ['bash', str(ROOT / 'scripts/install-bob-skill.sh'), directory]
+            subprocess.run(command, check=True, capture_output=True)
+            source = ROOT / 'skills/setup-agentic-scaffolding/references/bob-mcp.md'
+            installed = Path(directory) / '.bob/skills/setup-agentic-scaffolding/references/bob-mcp.md'
+            self.assertEqual(installed.read_bytes(), source.read_bytes())
+            installed.write_text('stale instructions')
+            stale = installed.parent / 'obsolete.md'
+            stale.write_text('obsolete')
+            subprocess.run(command, check=True, capture_output=True)
+            self.assertEqual(installed.read_bytes(), source.read_bytes())
+            self.assertFalse(stale.exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^skills/setup-agentic-scaffolding/SKILL\\.md$/",
+        "/^skills/setup-agentic-scaffolding/references/.*\\.md$/",
         "/^README\\.md$/",
         "/^gemini-extension\\.json$/"
       ],
@@ -30,6 +31,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^skills/setup-agentic-scaffolding/SKILL\\.md$/",
+        "/^skills/setup-agentic-scaffolding/references/.*\\.md$/",
         "/^README\\.md$/",
         "/^gemini-extension\\.json$/"
       ],

--- a/scripts/install-bob-skill.sh
+++ b/scripts/install-bob-skill.sh
@@ -7,7 +7,7 @@
 # ~/.bob/skills/), so prefer that. Use this script when you cannot run the skills CLI.
 #
 # IBM Bob discovers skills under .bob/skills/ (per project) or ~/.bob/skills/ (global).
-# This copies each skill's SKILL.md and its templates/ (when present) into the chosen
+# This copies each skill's SKILL.md and its templates/ and references/ (when present) into the chosen
 # location. All three skills are installed: setup-agentic-scaffolding, scaffold-project,
 # and audit-project.
 #
@@ -59,10 +59,12 @@ for SKILL_NAME in "${SKILL_NAMES[@]}"; do
   # metadata and is intentionally not copied.
   mkdir -p "$DEST"
   cp "$SRC/SKILL.md" "$DEST/SKILL.md"
-  rm -rf "$DEST/templates"
-  if [[ -d "$SRC/templates" ]]; then
-    cp -R "$SRC/templates" "$DEST/templates"
-  fi
+  for support in templates references; do
+    rm -rf "${DEST:?}/${support:?}"
+    if [[ -d "$SRC/$support" ]]; then
+      cp -R "$SRC/$support" "$DEST/$support"
+    fi
+  done
 
   echo "Installed '$SKILL_NAME' into: $DEST"
 done

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.22.0
+# Version: 0.22.1
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.22.0
+# Version: 0.22.1
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.22.0
+# Version: 0.22.1
 
 ## 1. When to use this skill
 
@@ -120,32 +120,10 @@ immediately — Copilot CLI registers live, opencode hot-reloads, Bob restarts c
 even a `claude mcp list` health check launches each server it lists — so tell the user plainly
 that the download happens at that moment, not at some later first use.
 
-**Both versions are pinned on purpose.** Left floating, `@upstash/context7-mcp` and the JBang
-catalog alias `quarkus-agent-mcp@quarkusio` (whose script-ref is the moving
-`io.quarkus:quarkus-agent-mcp:RELEASE:runner`) each fetch whatever is newest at the moment the
-server starts, so two machines set up a week apart run different code and neither the user nor this
-skill can say which. A pinned version makes the artifact the runtime resolves from its official
-registry explicit, and every upgrade a reviewable change. Register the exact strings above — do
-not drop the version to "get the latest". Keeping them current is automation's job: Renovate
-watches these pins (`renovate.json`, `customManagers`) and opens a PR when upstream publishes a
-new release. Two notes on the pinned
-GAV: it is the same artifact the `quarkusio` catalog alias points at, only resolved to an explicit
-version, and a raw GAV drops the alias's `java-version: 21+` hint — which is why the registration
-carries `--java 21+` explicitly (see below).
-
-**`--java 21+` is part of the command, not decoration.** Do not drop it, and do not assume Phase A
-covers it. Phase A proves the *machine* has a JDK 25; it does not decide which JDK JBang picks.
-JBang resolves that itself, and it falls back to its own default JDK — 17 on JBang 0.125.x —
-whenever the process that spawned it exports no `JAVA_HOME` (GUI- and IDE-launched agents typically
-do not) or points at a JDK older than 21. Switching to the `quarkus-agent-mcp@quarkusio` alias does
-not save you either: the catalog entry does declare `java-version: 21+`, but JBang 0.125.x ignores
-it for a GAV `script-ref`, so the alias fails identically. The server is compiled for Java 21, so it
-then dies at boot with
-`UnsupportedClassVersionError: … class file version 65.0 … only recognizes … up to 61.0`, the client
-retries a few times and gives up, and the failure looks like "the MCP is not working" rather than a
-JDK mismatch. A terminal-launched agent that inherits a modern `JAVA_HOME` gets away without the
-flag by accident of the environment — which is precisely why the flag belongs in the command.
-`21+` is a floor, not a pin: JBang reuses an already-installed newer JDK instead of downloading 21.
+**Register the exact pinned versions above, including `--java 21+`.** Renovate maintains both
+pins; keep upgrades reviewable. Phase A verifies the machine's JDK, but JBang selects its own:
+`21+` enforces the server's Java floor while allowing an installed newer JDK. The historical
+JDK failure and catalog-alias analysis are recorded in the repository's v0.18.0 changelog.
 
 **Never handle a secret in plaintext.** Do not ask the user to paste an API key into the chat, do
 not embed a literal key in a command or a config file you write, and do not echo one back in
@@ -166,7 +144,7 @@ secrets by design (see the context7 note above), so "exact" is literal: what you
 | Cursor | Write `.cursor/mcp.json` with both servers (`mcpServers` map, same command/args) | Settings → MCP shows both; user **toggles them on** | GUI enable |
 | GitHub Copilot CLI | `copilot mcp add quarkus-agent -- jbang --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `copilot mcp add context7 -- npx -y @upstash/context7-mcp@4.0.6` | `copilot mcp list` | **Yes** — live immediately |
 | opencode | Write `opencode.json` `mcp` key with both servers | `/mcp` in session | **Yes** — hot reload |
-| Bob (D3) | `bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.6` — the `--` is mandatory, and `-s global` is machine-wide: state that to the user and offer `-s workspace` to stack-mixers (both §5.1) | `bob mcp list` shows both, `stdio`, `global` (or `workspace`) | **Yes** — Bob restarts changed servers |
+| Bob (D3; read §5.1 first) | `bob mcp add -s global quarkus-agent jbang -- --java 21+ io.quarkus:quarkus-agent-mcp:1.2.6:runner` · `bob mcp add -s global context7 npx -- -y @upstash/context7-mcp@4.0.6` — the `--` is mandatory, and `-s global` is machine-wide: state that to the user and offer `-s workspace` to stack-mixers (both §5.1) | `bob mcp list` shows both, `stdio`, `global` (or `workspace`) | **Yes** — Bob restarts changed servers |
 
 The `.cursor/mcp.json`, `opencode.json`, and `.bob/mcp.json` map has the same shape everywhere:
 
@@ -212,64 +190,11 @@ manual install per JBang's docs (`~/.jbang/bin`) puts `jbang` there. The symptom
 probe runs in your login shell. When a client fails that way, register the **absolute path** from
 `command -v jbang` as the command, with the same arguments.
 
-### 5.1 Bob: which file, and the `--` separator
+### 5.1 Bob registration reference
 
-Bob 2.0.0 ships `bob mcp add|add-json|list|remove`, so prefer the CLI over hand-writing JSON — it
-writes the file Bob actually reads and `bob mcp list` is a real verification. Four things to know:
-three the CLI enforces, one Bob's loader does.
-
-- **Probe for the legacy file BEFORE the first `add` — this ordering is load-bearing.** Bob migrates
-  `~/.bob/settings/mcp_settings.json` into `mcp.json` **only when `mcp.json` does not yet exist**.
-  `bob mcp add -s global` creates `mcp.json`, so registering first blocks that migration
-  permanently: on a machine whose global config still lives in the legacy file, our two servers land
-  in a fresh `mcp.json` and **every other server the user configured silently stops loading**. So:
-  if the legacy file exists and `mcp.json` does not, have the user start Bob once and let it migrate
-  (it announces *"your global MCP configuration has been migrated to mcp.json"*), confirm the
-  servers survived, and only then register. Never resolve this by copying files around yourself
-  without showing the user both files first.
-- **`--` before the server's own arguments is mandatory.** `bob mcp add … jbang --java 21+ <GAV>`
-  fails with `error: unknown option '--java'`, because Bob parses the flag as its own. With the
-  separator (`… jbang -- --java 21+ <GAV>`) the arguments land verbatim in the entry's `args`.
-- **`add` never updates an existing entry — `add-json` does.** On a name that is already registered,
-  `bob mcp add` exits 1 with `Error: MCP server "…" already exists in …` and leaves the old entry
-  untouched, so an idempotent re-run cannot repair a stale registration through it — neither an
-  unpinned `quarkus-agent` command nor the `context7` entry every version bump leaves behind. Use
-  `bob mcp add-json`, which overwrites in place — still the CLI, so the file Bob reads stays the
-  one being written. One form per server:
-  `bob mcp add-json -s <scope> quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.6:runner"]}'`
-  · `bob mcp add-json -s <scope> context7 '{"command":"npx","args":["-y","@upstash/context7-mcp@4.0.6"]}'`.
-  Show the user the current entry and confirm before overwriting; `bob mcp remove` then `add`
-  works too, but loses the entry if the add fails.
-- **`-s global` is a scope decision — state it, never make it silently.** It writes
-  `~/.bob/settings/mcp.json` (creating file and directory if needed) and registers the servers for
-  **every workspace on the machine**, not just this project. That is this skill's default because
-  the servers are tools, not conventions — they change nothing in projects that never call them —
-  and re-registering per project is friction; but tell the user that is the scope they are getting,
-  and offer `-s workspace` to anyone who mixes stacks and wants the registration confined to the
-  current project. `-s workspace` (Bob's own default) writes `<project>/.bob/mcp.json` but does
-  **not** create it — it exits with `Fatal error: ENOENT … .bob/mcp.json`. Seed it **only when it
-  is missing**, because `>` truncates and an existing file holds the user's other servers:
-  `[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }`. At
-  workspace scope the verify column reads `workspace`, and the legacy-migration probe in the first
-  bullet still applies before any *global* add.
-- **Never write `mcp_settings.json` yourself** (Bob's loader, not the CLI). A registration written
-  there on a machine that already has `mcp.json` is silently ignored — it looks registered and Bob
-  never loads it. Check `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` too: one directory **above**
-  the settings directory, where releases of this skill before v0.18.0 told agents to write. Bob reads
-  neither and migrates neither, so a machine set up by an earlier run may hold a registration there
-  that has never loaded. If you find one, report it and register through the CLI instead.
-
-A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
-shallower one in the same workspace. When something still fails to start, Bob's own log is the
-evidence: `~/.bob/logs/shell/` — a `UnsupportedClassVersionError` there is the JDK trap from §5.
-
-**No `bob` on PATH?** Probe with `command -v bob` before you plan the registration: a Bob-IDE-only
-machine has no CLI, and the whole route above is unavailable. Then hand-write the file — global
-`~/.bob/settings/mcp.json`, project `<project>/.bob/mcp.json` — read-modify-write so the user's
-other servers survive, with the entries from §5 including `--java 21+`. Verify in the UI's **MCP**
-tab, which lists what Bob actually loaded; that is the one verification that needs no binary.
-Every rule above still applies: not the legacy name, not a truncating write, and Bob reloads
-changed servers on its own.
+**If running in Bob, read [Bob MCP registration](references/bob-mcp.md) before any registration.**
+It covers legacy migration before the first add, scope, safe updates, missing-CLI fallback, and
+verification. Preserve the `--` separator and state the selected scope to the user.
 
 ### 5.2 Restart handoff
 

--- a/skills/setup-agentic-scaffolding/references/bob-mcp.md
+++ b/skills/setup-agentic-scaffolding/references/bob-mcp.md
@@ -1,0 +1,59 @@
+# Bob MCP registration
+
+Bob 2.0.0 ships `bob mcp add|add-json|list|remove`, so prefer the CLI over hand-writing JSON — it
+writes the file Bob actually reads and `bob mcp list` is a real verification. Four things to know:
+three the CLI enforces, one Bob's loader does.
+
+- **Probe for the legacy file BEFORE the first `add` — this ordering is load-bearing.** Bob migrates
+  `~/.bob/settings/mcp_settings.json` into `mcp.json` **only when `mcp.json` does not yet exist**.
+  `bob mcp add -s global` creates `mcp.json`, so registering first blocks that migration
+  permanently: on a machine whose global config still lives in the legacy file, our two servers land
+  in a fresh `mcp.json` and **every other server the user configured silently stops loading**. So:
+  if the legacy file exists and `mcp.json` does not, have the user start Bob once and let it migrate
+  (it announces *"your global MCP configuration has been migrated to mcp.json"*), confirm the
+  servers survived, and only then register. Never resolve this by copying files around yourself
+  without showing the user both files first.
+- **`--` before the server's own arguments is mandatory.** `bob mcp add … jbang --java 21+ <GAV>`
+  fails with `error: unknown option '--java'`, because Bob parses the flag as its own. With the
+  separator (`… jbang -- --java 21+ <GAV>`) the arguments land verbatim in the entry's `args`.
+- **`add` never updates an existing entry — `add-json` does.** On a name that is already registered,
+  `bob mcp add` exits 1 with `Error: MCP server "…" already exists in …` and leaves the old entry
+  untouched, so an idempotent re-run cannot repair a stale registration through it — neither an
+  unpinned `quarkus-agent` command nor the `context7` entry every version bump leaves behind. Use
+  `bob mcp add-json`, which overwrites in place — still the CLI, so the file Bob reads stays the
+  one being written. One form per server:
+  `bob mcp add-json -s <scope> quarkus-agent '{"command":"jbang","args":["--java","21+","io.quarkus:quarkus-agent-mcp:1.2.6:runner"]}'`
+  · `bob mcp add-json -s <scope> context7 '{"command":"npx","args":["-y","@upstash/context7-mcp@4.0.6"]}'`.
+  Show the user the current entry and confirm before overwriting; `bob mcp remove` then `add`
+  works too, but loses the entry if the add fails.
+- **`-s global` is a scope decision — state it, never make it silently.** It writes
+  `~/.bob/settings/mcp.json` (creating file and directory if needed) and registers the servers for
+  **every workspace on the machine**, not just this project. That is this skill's default because
+  the servers are tools, not conventions — they change nothing in projects that never call them —
+  and re-registering per project is friction; but tell the user that is the scope they are getting,
+  and offer `-s workspace` to anyone who mixes stacks and wants the registration confined to the
+  current project. `-s workspace` (Bob's own default) writes `<project>/.bob/mcp.json` but does
+  **not** create it — it exits with `Fatal error: ENOENT … .bob/mcp.json`. Seed it **only when it
+  is missing**, because `>` truncates and an existing file holds the user's other servers:
+  `[ -f .bob/mcp.json ] || { mkdir -p .bob && printf '{"mcpServers":{}}\n' > .bob/mcp.json; }`. At
+  workspace scope the verify column reads `workspace`, and the legacy-migration probe in the first
+  bullet still applies before any *global* add.
+- **Never write `mcp_settings.json` yourself** (Bob's loader, not the CLI). A registration written
+  there on a machine that already has `mcp.json` is silently ignored — it looks registered and Bob
+  never loads it. Check `~/.bob/mcp.json` and `~/.bob/mcp_settings.json` too: one directory **above**
+  the settings directory, where releases of this skill before v0.18.0 told agents to write. Bob reads
+  neither and migrates neither, so a machine set up by an earlier run may hold a registration there
+  that has never loaded. If you find one, report it and register through the CLI instead.
+
+A same-named server at workspace scope overrides global, and a deeper `.bob/mcp.json` overrides a
+shallower one in the same workspace. When something still fails to start, Bob's own log is the
+evidence: `~/.bob/logs/shell/` — a `UnsupportedClassVersionError` there is the JDK trap from [setup §5](../SKILL.md#5-phase-b--mcp-registration-per-agent).
+
+**No `bob` on PATH?** Probe with `command -v bob` before you plan the registration: a Bob-IDE-only
+machine has no CLI, and the whole route above is unavailable. Then hand-write the file — global
+`~/.bob/settings/mcp.json`, project `<project>/.bob/mcp.json` — read-modify-write so the user's
+other servers survive, with the entries from [setup §5](../SKILL.md#5-phase-b--mcp-registration-per-agent) including `--java 21+`. Verify in the UI's **MCP**
+tab, which lists what Bob actually loaded; that is the one verification that needs no binary.
+Every rule above still applies: not the legacy name, not a truncating write, and Bob reloads
+changed servers on its own.
+

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.22.0
+# Version: 0.22.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.22.0
+# Version: 0.22.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
The setup skill loaded Bob-specific details for every client and duplicated them in the README. Move them into one mandatory, conditional reference, retain shared pin/Java instructions, and point the README to the same procedure.

Ship and refresh references through the Bob fallback installer. Extend Renovate and MCP command checks to cover the moved pins. Main SKILL size falls from 7,246 to 5,545 tokens (tiktoken 0.14.0, o200k_base); this excludes the additional reference Bob loads.

Closes #22.

Plan approved; independent Standards and Spec reviews reported zero findings. Checks passed: 16 Python tests including installation/refresh, Markdown lint, ShellCheck, actionlint, and version/seed/MCP consistency. Prepares v0.22.1.
