### PR TITLE
docs: record decision to defer default agentic compensation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.23.0
+# Version: 0.23.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.23.1 — 2026-09-09
+
+### Documentation
+
+- Record the deliberate deferral of a global agentic-compensation convention (#48), separating
+  verified upstream behavior from unverified Quarkus wiring and defining concrete adoption tests.
+
 ## v0.23.0 — 2026-09-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.23.0
+# Version: 0.23.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.23.0
+# Version: 0.23.1
 
 ## What this repository is
 
@@ -260,6 +260,9 @@ so the Claude and Codex packages share the same skill content. Bob has a marketp
 distributes modes and MCP servers rather than skills (and is IBM-internal), so there is no
 marketplace channel for skills: Bob's are installed by the skills CLI (or
 `scripts/install-bob-skill.sh`) into `.bob/skills/`.
+
+The [agentic compensation decision](docs/AGENTIC-COMPENSATION.md) records why compensation
+remains outside the default conventions and what runtime evidence would justify adopting it.
 
 ## Advanced — personal use (optional global install)
 

--- a/docs/AGENTIC-COMPENSATION.md
+++ b/docs/AGENTIC-COMPENSATION.md
@@ -1,0 +1,53 @@
+# Agentic compensation: defer the default convention
+
+Decision for [issue #48](https://github.com/eldermoraes/quarkus-agentic-scaffolding/issues/48),
+2026-09-09: keep compensation out of the global §4 conventions and starter templates for now.
+Current templates remain valid. Compensation may be appropriate for a specific application after
+its integration and failure semantics are tested; it is not a universal requirement for every tool.
+
+## Verified evidence
+
+Context7 was queried first for upstream documentation. LangChain4j documents optional cross-agent
+compensation via `compensateOnError`, with `@CompensateFor` connecting a tool to its compensator.
+Successful tool calls with a compensator are processed in reverse order; missing compensators are
+skipped. Compensation is best effort: one compensator failing does not prevent the remaining ones
+from running. This is not guaranteed transactional rollback.
+See [agent workflows](https://docs.langchain4j.dev/tutorials/agents#cross-agent-compensation) and
+[tool compensation](https://docs.langchain4j.dev/tutorials/tools).
+
+The local `langchain4j-agentic:1.19.0-beta29` binary exposes `compensateOnError()` on
+`dev.langchain4j.agentic.declarative.ParallelAgent`, verified with `javap`.
+
+However, inspection did **not** reproduce the issue's claim that Quarkus integration processors
+reference `compensateOnError` and `CompensateFor`:
+
+- The `quarkus-langchain4j-agentic-deployment` class archives for 1.13.0 and 1.13.1 contain neither
+  literal, while `BeforeCall` is present.
+- The 1.13.1 published sources for `AgenticProcessor.java` and `AgenticLangChain4jDotNames.java`
+  also contain neither literal. The inspected
+  [Maven Central source archive](https://repo.maven.apache.org/maven2/io/quarkiverse/langchain4j/quarkus-langchain4j-agentic-deployment/1.13.1/quarkus-langchain4j-agentic-deployment-1.13.1-sources.jar)
+  has SHA-256 `97d6ad3cf59b3aaaadb30f1a210bd1a92dd4039dbfb709fb95f93c90bcb240fe`.
+- The [Quarkiverse agentic guide](https://docs.quarkiverse.io/quarkus-langchain4j/dev/agentic.html)
+  did not document compensation when checked on this date.
+
+Absence of these symbols is not proof that runtime support is absent. It means the specific
+integration evidence in the issue remains unverified. An upstream annotation compiling is also
+insufficient evidence that a Quarkus-managed workflow enables its behavior.
+
+## Adoption criteria
+
+Reconsider a convention or opt-in template when the Quarkus integration is documented or a
+minimal Quarkus-managed runtime test demonstrates all of these behaviors:
+
+1. A successful externally visible tool action is followed by a workflow failure and its
+   compensator executes.
+2. Multiple successful tool calls are compensated in the expected reverse order.
+3. A failing compensator does not prevent remaining compensators from running, and the failure
+   is observable to operators.
+4. The application defines idempotency and recovery behavior for retries, partial success and
+   irreversible actions; it does not assume an annotation guarantees rollback.
+5. JVM wiring is exercised, plus native wiring when the application targets a native binary.
+
+This decision adds no compensation example that could imply unverified runtime guarantees.
+`BeforeCall` and `writeStateIfAbsent` are separate capabilities and are not prerequisites for
+closing this adoption decision.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.23.0
+# Version: 0.23.1
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.23.0
+# Version: 0.23.1
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.23.0
+# Version: 0.23.1
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.23.0
+# Version: 0.23.1
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.23.0
+# Version: 0.23.1
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Record the deliberate decision to keep agentic compensation out of default conventions and templates until Quarkus-managed runtime behavior is verified. Upstream compensation semantics are documented, but inspection did not reproduce the integration-processor symbols asserted in the issue; the decision explicitly avoids treating that absence as proof of unsupported behavior.

Define concrete adoption tests covering actual compensation, reverse ordering, compensator failure, idempotency and JVM/native wiring where applicable. No application behavior changes.

Closes #48.

Plan approved; independent Standards and Spec reviews reported zero findings. Markdown lint and version, seed and MCP consistency checks passed. Prepares v0.23.1.
