### PR TITLE
docs: prepare current community marketplace submission

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "eldermoraes",
+  "description": "Quarkus + LangChain4j agentic scaffolding, setup and audit skills by Elder Moraes.",
   "owner": {
     "name": "Elder Moraes",
     "email": "elder.moraes@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agentic-scaffolding",
   "displayName": "Quarkus Agentic Scaffolding",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "skills": [
     "./skills/setup-agentic-scaffolding",
     "./skills/scaffold-project",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Three-skill flow for building Quarkus + LangChain4j agentic AI applications in Codex: setup-agentic-scaffolding (prerequisites: toolchain, Quarkus Agents MCP + context7, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions). Pairs with the repository's AGENTS.md conventions.",
   "author": {
     "name": "Elder Moraes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.23.1
+# Version: 0.23.2
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this artifact are documented here. This project adheres to semantic
 versioning.
 
+## v0.23.2 — 2026-09-09
+
+### Documentation
+
+- Refresh the Anthropic community-marketplace submission kit with the current three-skill
+  identity, accurate execution scope and validator results (#4). Actual authenticated submission
+  remains pending; no listing or acceptance is claimed.
+- Add the marketplace description required to clear its validator warning.
+
 ## v0.23.1 — 2026-09-09
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.23.1
+# Version: 0.23.2
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quarkus + LangChain4j + AI Stack
-# Version: 0.23.1
+# Version: 0.23.2
 
 ## What this repository is
 
@@ -578,6 +578,9 @@ The [12-run pilot](evals/skill-pilot/results/2026-09-09/REPORT.md) was inconclus
 produced Java because required documentation services were unavailable or quota-limited. This
 is not evidence of benefit or parity. The [protocol and runner](evals/skill-pilot/README.md) publish
 fixed tasks, mechanical scoring, and every observed result; a valid comparison remains pending.
+
+The [Anthropic community submission kit](docs/ANTHROPIC-SUBMISSION.md) is prepared and validated;
+submission remains pending authentication. No community or official-directory listing is claimed.
 
 ## Versioning and changelog
 

--- a/docs/ANTHROPIC-SUBMISSION.md
+++ b/docs/ANTHROPIC-SUBMISSION.md
@@ -1,0 +1,87 @@
+# Anthropic community submission kit
+
+Prepared 2026-09-09 for [issue #4](https://github.com/eldermoraes/quarkus-agentic-scaffolding/issues/4).
+**Not submitted.** The Console URL was opened in a browser and displayed login, not submission
+fields. The values below come from repository manifests; field names/category are inferred until
+an authenticated form is inspected. This replaces the obsolete v0.8.0 single-skill worksheet.
+
+## Destination and completion
+
+Use the [Console submission form](https://platform.claude.com/plugins/submit) for an individual
+author. Anthropic's [submission documentation](https://code.claude.com/docs/en/plugins#submit-your-plugin-to-the-community-marketplace)
+identifies this as review for `claude-community`. The separate `claude-plugins-official` marketplace
+is curated by Anthropic and has no application process. Submission does not guarantee acceptance.
+
+Authenticate, match the live fields to the values below, inspect any required declarations, and
+submit only when those declarations are accurate. Record the actual receipt or submission ID in
+issue #4; keep the issue open until that exists. If accepted, verify the plugin appears in the
+[community catalog](https://github.com/anthropics/claude-plugins-community) before claiming it is
+installable there.
+
+## Values for the live form
+
+| Meaning | Value |
+| --- | --- |
+| Plugin identifier | `quarkus-agentic-scaffolding` |
+| Display name | Quarkus Agentic Scaffolding |
+| Repository/homepage | `https://github.com/eldermoraes/quarkus-agentic-scaffolding` |
+| Marketplace | `eldermoraes` |
+| Plugin manifest | `.claude-plugin/plugin.json` |
+| Marketplace manifest | `.claude-plugin/marketplace.json` |
+| Author | Elder Moraes |
+| Public maintainer contact | `elder.moraes@gmail.com` |
+| License | `Apache-2.0` |
+| Suggested category, if offered | Developer Tools |
+| Keywords | quarkus, langchain4j, ai, agents, rag, mcp, scaffolding, setup, audit, java |
+| Version | Read `version` from `.claude-plugin/plugin.json` at submission time |
+| Review commit, if requested | Resolve the current release tag to its commit at submission time |
+
+Short description:
+
+> Setup, scaffold and audit Quarkus + LangChain4j agentic Java applications using shared
+> conventions and build-checked templates.
+
+Long description:
+
+> Quarkus Agentic Scaffolding provides three skills: setup-agentic-scaffolding prepares toolchain,
+> MCP registration and project conventions; scaffold-project creates projects and adds AI services,
+> workflows, RAG and MCP components; audit-project reviews conformance. Project creation and
+> Quarkus work use the external Quarkus Agents MCP, and library documentation uses Context7.
+> Templates are checked by CI against the configured Quarkus platform; generated application
+> behavior still needs project-specific review and tests. The setup skill copies conventions into
+> the project so they are loaded as project context.
+
+## Scope statement for reviewers
+
+The Claude manifests declare three skill directories and no hooks, MCP servers, LSP servers,
+background monitors or telemetry components. Their absence is a statement about inspected plugin
+declarations, not a claim about the host agent or third-party services.
+
+Invoked skills can perform actions: setup probes prerequisites, proposes tool installation,
+registers external MCP configuration with the user's approval, and writes project conventions;
+scaffolding creates files and uses external tooling; auditing is read-only by default. MCP tools,
+package downloads, documentation queries and builds can use the network. Generated applications
+may call model providers according to their own configuration.
+
+The repository also contains installation/uninstallation helpers, CI/check/release scripts and
+an opt-in evaluation runner. These are not a single copy-only executable and are not automatically
+run by a Claude manifest declaration. Bob's fallback installer refreshes skill supporting files.
+The separate Gemini extension declares the two external MCP servers; that is a different
+installation route. Review the repository rather than assuming every distribution loads the same
+components. Do not claim that external tools are telemetry-free or that this repository never
+performs network requests.
+
+## Validation record
+
+Validated on 2026-09-09 with Claude Code `2.1.266`:
+
+```sh
+claude plugin validate .claude-plugin/marketplace.json
+claude plugin validate .claude-plugin/plugin.json
+```
+
+Marketplace validation passes without warnings after adding its optional description. Plugin
+validation passes with one warning: root `CLAUDE.md` is not automatically loaded as project
+context. This is expected for this package: setup ships convention seeds and copies them into the
+user's project. The submission must not suggest that installing the plugin alone loads those
+conventions. Re-run both checks against the exact version being submitted.

--- a/docs/EVOLUTION-PLAN.md
+++ b/docs/EVOLUTION-PLAN.md
@@ -14,7 +14,7 @@
 | quarkus-langchain4j | (platform-managed) | Standalone BOM **1.12.0** (tracks LangChain4j 1.17.2); platform 3.37.2 ships 1.11.2 (LC4j 1.16.2) |
 | LangChain4j core | 1.14.1 / agentic beta24 | **1.17.2 / agentic 1.17.2-beta27** — still experimental, plus `@LoopAgent`, `@ConditionalAgent`, `@PlannerAgent`, `@ErrorHandler`, human-in-the-loop, guardrails module, A2A 1.0.0.Final |
 | Java | 25 LTS floor (correct) | 26 is current GA; 27 GA 2026-09-14; **GraalVM ships no 26/27/28 releases** — native stays on the 25 baseline until JDK 29 (Sept 2027) |
-| Distribution | self-hosted marketplace only | Official Anthropic plugin directory (submission form), skills.sh (`npx skills add`, 72+ agents), Gemini CLI gallery (topic-driven), AGENTS.md now a Linux Foundation (AAIF) standard |
+| Distribution | self-hosted marketplace only | Anthropic community marketplace (submission form), skills.sh (`npx skills add`, 72+ agents), Gemini CLI gallery (topic-driven), AGENTS.md now a Linux Foundation (AAIF) standard |
 | Repo visibility | — | **0 stars, no GitHub description, no topics, no homepage** (verified via GitHub API); already listed on jvmskills.com |
 
 The three user-declared open questions — adoption, staying current with Quarkus/LangChain4j, and
@@ -48,13 +48,13 @@ leaderboard ranks purely by install telemetry, so every documented install compo
 Add this as the first install option in the README, keeping `/plugin marketplace add` for Claude
 and the Codex/Bob paths as-is.
 
-### 3. Submit to the official Anthropic plugin directory *(one form; adoption)* — ⏳ pending user action: submission kit ready in [issue #4](https://github.com/eldermoraes/quarkus-agentic-scaffolding/issues/4)
-Anthropic now runs a curated directory ([claude.com/plugins](https://claude.com/plugins),
-[anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official)) plus a
-community tier ([anthropics/claude-plugins-community](https://github.com/anthropics/claude-plugins-community))
-surfaced in Claude Code's `/plugin` Discover tab. Submission is via the form at
-**clau.de/plugin-directory-submission** (direct PRs are auto-closed). This is the single
-highest-surface listing available for the Claude side.
+### 3. Submit for Anthropic community-marketplace review *(one form; adoption)* — ⏳ pending authenticated submission
+
+The [current submission kit](ANTHROPIC-SUBMISSION.md) supersedes the v0.8.0 worksheet in
+[issue #4](https://github.com/eldermoraes/quarkus-agentic-scaffolding/issues/4). Use the
+[Console form](https://platform.claude.com/plugins/submit) for an individual author. The form
+submits to the community marketplace; inclusion in the separately curated official marketplace
+has no application process. Authentication and a submission receipt are still outstanding.
 
 ### 4. Refresh the model defaults *(small template edit)* — ✅ done 2026-08-10 (v0.15.0: qwen3:4b / qwen3:1.7b and bge-small-en-v15-q)
 - **Chat:** the official quarkus-langchain4j Ollama guide now uses **`qwen3:1.7b`**

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "quarkus-agentic-scaffolding",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Three-skill flow and always-on conventions for building Quarkus + LangChain4j agentic AI applications: setup (toolchain, MCP servers, conventions file), scaffold-project (create projects and add AI services, agents, RAG, and MCP clients/servers), and audit-project (audit an existing project against the conventions).",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/skills/audit-project/SKILL.md
+++ b/skills/audit-project/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Audit a Quarkus + LangChain4j Project
 
-# Version: 0.23.1
+# Version: 0.23.2
 
 ## Gate: verify the MCP first
 

--- a/skills/scaffold-project/SKILL.md
+++ b/skills/scaffold-project/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold Quarkus + LangChain4j projects end-to-end and add agentic 
 ---
 
 # Quarkus + LangChain4j Scaffolding
-# Version: 0.23.1
+# Version: 0.23.2
 
 **Prerequisites.** The Quarkus Agents MCP, context7, and the project conventions file
 (`CLAUDE.md` for Claude, `AGENTS.md` for Codex) should already be configured — if they are

--- a/skills/setup-agentic-scaffolding/SKILL.md
+++ b/skills/setup-agentic-scaffolding/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 # Setup Agentic Scaffolding
-# Version: 0.23.1
+# Version: 0.23.2
 
 ## 1. When to use this skill
 

--- a/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-AGENTS.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack - Project Conventions
-# Version: 0.23.1
+# Version: 0.23.2
 
 These conventions apply whenever Codex or Bob writes, reviews, or configures code in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in

--- a/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
+++ b/skills/setup-agentic-scaffolding/templates/conventions-CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- BEGIN quarkus-agentic-scaffolding conventions (managed block; do not edit inside. Re-run /setup-agentic-scaffolding to update.) -->
 
 # Quarkus + LangChain4j + AI Stack — Project Conventions
-# Version: 0.23.1
+# Version: 0.23.2
 
 These conventions apply whenever code is written, reviewed, or configured in a Quarkus +
 LangChain4j project. They are always-on. Procedural scaffolding steps and starter code live in


### PR DESCRIPTION
Refresh the community marketplace submission kit for the current plugin identity and three skills. Distinguish the community review route from the curated official marketplace, accurately describe executable and network behavior, and record manifest validation results.

Refs #4. Submission remains pending authentication and an actual receipt; this PR does not close the issue.

Validation: independent Standards and Spec reviews found no actionable issues; version, convention parity, MCP consistency and diff checks pass. Claude manifest validation passes, with the documented root CLAUDE.md warning only for the plugin. Prepare v0.23.2.
